### PR TITLE
Fix Neptune edge loading by adding S3 notification for output-edges

### DIFF
--- a/docker/app/version.json
+++ b/docker/app/version.json
@@ -1,5 +1,5 @@
 {
   "version": "2.0.0",
-  "build_date": "2025-10-27T19:20:48.605Z",
+  "build_date": "2025-10-28T14:54:40.191Z",
   "git_commit": "local-dev"
 }

--- a/lib/graph-db-stack.ts
+++ b/lib/graph-db-stack.ts
@@ -622,11 +622,18 @@ export class GraphDbStack extends cdk.Stack {
     dataLoaderLambda.addToRolePolicy(createDynamoDBPolicy(bulkLoadLogTable.tableName));
     dataLoaderLambda.addToRolePolicy(createS3Policy(etlDataBucket.bucketName));
 
-    // S3 notification for data loading
+    // S3 notification for data loading - vertices
     etlDataBucket.addEventNotification(
       s3.EventType.OBJECT_CREATED,
       new s3n.LambdaDestination(dataLoaderLambda),
       { prefix: 'output/' }
+    );
+
+    // S3 notification for data loading - edges
+    etlDataBucket.addEventNotification(
+      s3.EventType.OBJECT_CREATED,
+      new s3n.LambdaDestination(dataLoaderLambda),
+      { prefix: 'output-edges/' }
     );
 
     // Save outputs to temp files

--- a/ui/version.json
+++ b/ui/version.json
@@ -1,5 +1,5 @@
 {
   "version": "2.0.0",
-  "build_date": "2025-10-27T19:20:48.605Z",
+  "build_date": "2025-10-28T14:54:40.191Z",
   "git_commit": "local-dev"
 }


### PR DESCRIPTION
Title: Fix Neptune edge loading by adding S3 notification for output-edges

Description:
## Problem
Edge CSV files created by the ETL processor in `output-edges/` were not being loaded into Neptune, resulting in graphs with vertices but no relationships (0 edges).

## Root Cause
The S3 event notification only triggered the data loader Lambda for files in the `output/` prefix, not `output-edges/`.

## Solution
Added a second S3 event notification to trigger the data loader Lambda when files are created in `output-edges/`.

## Testing
- Verified edge CSV files are now loaded into Neptune
- Confirmed graph database shows both vertices and edges after ETL completion
