### PR TITLE
Deployment improvements

### DIFF
--- a/.kiro/steering/implementation-guide.md
+++ b/.kiro/steering/implementation-guide.md
@@ -40,13 +40,19 @@ source .venv/bin/activate
 
 ```bash
 # Deploy to AWS with default settings
-./dev-tools/deploy.sh
+./dev-tools/deploy.sh --region us-east-1
+
+# Deploy with specific AWS profile
+./dev-tools/deploy.sh --profile my-profile --region us-east-1
 
 # Deploy with Neptune graph database
-./dev-tools/deploy.sh --with-graph-db
+./dev-tools/deploy.sh --region us-east-1 --with-graph-db
+
+# Dry-run to validate without deploying
+./dev-tools/deploy.sh --dry-run --region us-east-1
 
 # CloudShell deployment (no local setup required)
-./scripts/cloudshell-deploy.sh
+./scripts/cloudshell-deploy.sh --region us-east-1
 ```
 
 ## Architecture Understanding
@@ -293,18 +299,29 @@ def test_your_agent_functionality():
 
 ```bash
 # Standard deployment
-./dev-tools/deploy.sh
+./dev-tools/deploy.sh --region us-east-1
+
+# With specific AWS profile
+./dev-tools/deploy.sh --profile prod --region us-east-1
 
 # With custom VPC
-./dev-tools/deploy.sh --vpc-id vpc-your-id
+./dev-tools/deploy.sh --region us-east-1 --vpc-id vpc-your-id
+
+# Enterprise deployment with bring-your-own networking
+./dev-tools/deploy.sh --profile prod --region us-east-1 \
+  --vpc-id vpc-123 \
+  --public-subnet-ids subnet-pub1,subnet-pub2 \
+  --private-subnet-ids subnet-priv1,subnet-priv2 \
+  --alb-security-group-id sg-alb \
+  --ecs-security-group-id sg-ecs
 
 # With monitoring and graph database
-./dev-tools/deploy.sh --with-graph-db
+./dev-tools/deploy.sh --region us-east-1 --with-graph-db
 ```
 
 ### CloudShell Deployment
 
-Use `./scripts/cloudshell-deploy.sh` for deployment without local setup requirements.
+Use `./scripts/cloudshell-deploy.sh --region us-east-1` for deployment without local setup requirements.
 
 ## Common Customization Scenarios
 

--- a/.kiro/steering/tech.md
+++ b/.kiro/steering/tech.md
@@ -79,17 +79,31 @@ npx cdk bootstrap
 
 ### Deployment
 ```bash
-# Deploy to AWS
-./dev-tools/deploy.sh
+# Deploy to AWS (basic)
+./dev-tools/deploy.sh --region us-east-1
+
+# Deploy with specific AWS profile
+./dev-tools/deploy.sh --profile my-profile --region us-east-1
 
 # Deploy with Neptune graph database
-./dev-tools/deploy.sh --with-graph-db
+./dev-tools/deploy.sh --region us-east-1 --with-graph-db
 
 # Deploy with existing VPC
-./dev-tools/deploy.sh --vpc-id vpc-123
+./dev-tools/deploy.sh --region us-east-1 --vpc-id vpc-123
+
+# Enterprise deployment with bring-your-own networking
+./dev-tools/deploy.sh --profile prod --region us-east-1 \
+  --vpc-id vpc-123 \
+  --public-subnet-ids subnet-pub1,subnet-pub2 \
+  --private-subnet-ids subnet-priv1,subnet-priv2 \
+  --alb-security-group-id sg-alb \
+  --ecs-security-group-id sg-ecs
+
+# Dry-run to validate without deploying
+./dev-tools/deploy.sh --dry-run --region us-east-1
 
 # CloudShell deployment
-./scripts/cloudshell-deploy.sh
+./scripts/cloudshell-deploy.sh --region us-east-1
 ```
 
 ### Container Operations

--- a/README.md
+++ b/README.md
@@ -8,15 +8,16 @@
 3. [Notes](#notes)
 4. [CloudShell Deployment](#cloudshell-deployment)
 5. [Local Deployment (Mac / Linux)](#local-deployment-mac--linux)
-6. [Deployment Validation](#deployment-validation)
-7. [Running the Guidance](#running-the-guidance)
-8. [Evaluation and Testing](#evaluation-and-testing)
-9. [Tracing and Observability](#tracing-and-observability)
-10. [Next Steps](#next-steps)
-11. [Cleanup](#cleanup)
-12. [Common issues, and debugging](#common-issues-and-debugging)
-13. [Revisions](#revisions)
-14. [Authors](#authors)
+6. [Windows Deployment (PowerShell)](#windows-deployment-powershell)
+7. [Deployment Validation](#deployment-validation)
+8. [Running the Guidance](#running-the-guidance)
+9. [Evaluation and Testing](#evaluation-and-testing)
+10. [Tracing and Observability](#tracing-and-observability)
+11. [Next Steps](#next-steps)
+12. [Cleanup](#cleanup)
+13. [Common issues, and debugging](#common-issues-and-debugging)
+14. [Revisions](#revisions)
+15. [Authors](#authors)
 
 ## Overview
 
@@ -320,6 +321,95 @@ npx cdk bootstrap aws://ACCOUNT_ID/us-west-2
 ./dev-tools/deploy-graph-db.sh
 ./dev-tools/deploy-graph-db.sh --vpc-id vpc-123  # with existing VPC
 ```
+
+## Windows Deployment (PowerShell)
+
+For Windows users who cannot use WSL, PowerShell deployment scripts are available.
+
+### Prerequisites
+
+- **Node.js 21.x+**: [Download](https://nodejs.org/)
+- **AWS CLI 2.27.51+**: [Install guide](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) + `aws configure`
+- **AWS CDK CLI**: `npm install -g aws-cdk`
+- **Python 3.13+**: [Download](https://www.python.org/downloads/)
+- **Docker Desktop**: [Download](https://www.docker.com/products/docker-desktop/) (required for container builds)
+- **PowerShell 5.1+** (included with Windows 10/11)
+
+### Quick Start
+
+```powershell
+# 1. Clone and setup
+git clone -b v2 https://github.com/aws-solutions-library-samples/guidance-for-agentic-data-exploration-on-aws.git
+cd guidance-for-agentic-data-exploration-on-aws
+npm install
+
+# 2. Bootstrap AWS (one-time per region)
+npx cdk bootstrap aws://ACCOUNT_ID/us-east-1
+
+# 3. Start Docker Desktop (ensure it's running)
+
+# 4. Deploy
+.\dev-tools\deploy.ps1 -Region us-east-1
+```
+
+### Deployment Options
+
+| Configuration | Command |
+|--------------|---------|
+| **New VPC, No Graph DB** | `.\dev-tools\deploy.ps1 -Region us-east-1` |
+| **New VPC with Graph DB** | `.\dev-tools\deploy.ps1 -Region us-east-1 -WithGraphDb` |
+| **Existing VPC** | `.\dev-tools\deploy.ps1 -Region us-east-1 -VpcId vpc-123` |
+| **With AWS Profile** | `.\dev-tools\deploy.ps1 -Profile my-profile -Region us-east-1` |
+| **Guardrails Mode** | `.\dev-tools\deploy.ps1 -Region us-east-1 -GuardrailMode enforce` |
+| **Dry Run** | `.\dev-tools\deploy.ps1 -DryRun -Region us-east-1` |
+
+### Enterprise Deployment
+
+```powershell
+# Full enterprise deployment with pre-created resources
+.\dev-tools\deploy.ps1 `
+  -Profile prod `
+  -Region us-east-1 `
+  -VpcId vpc-123 `
+  -PublicSubnetIds "subnet-pub1,subnet-pub2" `
+  -PrivateSubnetIds "subnet-priv1,subnet-priv2" `
+  -AlbSecurityGroupId sg-alb `
+  -EcsSecurityGroupId sg-ecs
+```
+
+### Available Parameters
+
+| Parameter | Description |
+|-----------|-------------|
+| `-Profile` | AWS CLI profile to use |
+| `-Region` | AWS region (e.g., us-east-1) |
+| `-Account` | AWS account ID (auto-detected if not provided) |
+| `-VpcId` | Existing VPC ID |
+| `-PublicSubnetIds` | Comma-separated public subnet IDs |
+| `-PrivateSubnetIds` | Comma-separated private subnet IDs |
+| `-AlbSecurityGroupId` | Security group ID for ALB |
+| `-EcsSecurityGroupId` | Security group ID for ECS tasks |
+| `-NeptuneSg` | Neptune security group ID |
+| `-NeptuneHost` | Neptune cluster endpoint |
+| `-WithGraphDb` | Deploy Neptune graph database |
+| `-GuardrailMode` | 'shadow' (default) or 'enforce' |
+| `-DryRun` | Validate without deploying |
+| `-SkipBootstrapCheck` | Skip CDK bootstrap verification |
+
+### Graph Database Only (Windows)
+
+```powershell
+.\dev-tools\deploy-graph-db.ps1 -Region us-east-1
+.\dev-tools\deploy-graph-db.ps1 -Region us-east-1 -VpcId vpc-123
+```
+
+### Notes for Windows Users
+
+- The PowerShell scripts use **Docker** instead of Podman (set via `CDK_DOCKER=docker`)
+- Knowledge base creation (`kb-create.ps1`) runs natively in PowerShell
+- If WSL is available, some scripts may fall back to bash for compatibility
+- Ensure Docker Desktop is running before deployment
+- Use backticks (`) for line continuation in PowerShell, not backslashes
 
 ## Deployment Validation
 

--- a/dev-tools/deploy-graph-db.ps1
+++ b/dev-tools/deploy-graph-db.ps1
@@ -1,0 +1,213 @@
+<#
+.SYNOPSIS
+    Deploy Graph Database Stack (Windows PowerShell version)
+
+.DESCRIPTION
+    Deploys the Neptune graph database stack for AI Data Explorer.
+
+.PARAMETER Profile
+    AWS CLI profile to use
+
+.PARAMETER Region
+    AWS region (e.g., us-east-1)
+
+.PARAMETER VpcId
+    Existing VPC ID (optional - creates new VPC if not provided)
+
+.PARAMETER DryRun
+    Show what would be deployed without deploying
+
+.EXAMPLE
+    .\deploy-graph-db.ps1 -Region us-east-1
+
+.EXAMPLE
+    .\deploy-graph-db.ps1 -Region us-east-1 -VpcId vpc-123
+#>
+
+[CmdletBinding()]
+param(
+    [string]$Profile,
+    [string]$Region,
+    [string]$VpcId,
+    [switch]$DryRun,
+    [switch]$Help
+)
+
+$ErrorActionPreference = "Stop"
+
+# Disable AWS CLI pager
+$env:AWS_PAGER = ""
+
+# Function to write colored output
+function Write-ColorOutput {
+    param(
+        [string]$Message,
+        [string]$Color = "White"
+    )
+    Write-Host $Message -ForegroundColor $Color
+}
+
+# Show help
+if ($Help) {
+    Write-ColorOutput "Deploy Graph Database Stack" -Color Blue
+    Write-Host ""
+    Write-Host "Usage: .\deploy-graph-db.ps1 [OPTIONS]"
+    Write-Host ""
+    Write-Host "Options:"
+    Write-Host "  -Profile PROFILE       AWS CLI profile to use"
+    Write-Host "  -Region REGION         AWS region (e.g., us-east-1)"
+    Write-Host "  -VpcId ID              Existing VPC ID (optional - creates new VPC if not provided)"
+    Write-Host "  -DryRun                Show what would be deployed without deploying"
+    Write-Host "  -Help                  Show this help message"
+    Write-Host ""
+    Write-Host "Examples:"
+    Write-Host "  .\deploy-graph-db.ps1 -Region us-east-1                    # Deploy with new VPC"
+    Write-Host "  .\deploy-graph-db.ps1 -Region us-east-1 -VpcId vpc-123     # Deploy with existing VPC"
+    Write-Host "  .\deploy-graph-db.ps1 -Profile prod -Region us-east-1     # Deploy with specific profile"
+    exit 0
+}
+
+# Get project root (script is in dev-tools folder)
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$ProjectRoot = Split-Path -Parent $ScriptDir
+Set-Location $ProjectRoot
+
+Write-ColorOutput "📊 Deploying Graph Database Stack..." -Color Blue
+
+# Set AWS profile if provided
+if ($Profile) {
+    $env:AWS_PROFILE = $Profile
+    Write-ColorOutput "Using AWS Profile: $Profile" -Color Yellow
+}
+
+# Set AWS region
+if ($Region) {
+    $env:AWS_REGION = $Region
+    $env:AWS_DEFAULT_REGION = $Region
+    $env:CDK_DEFAULT_REGION = $Region
+} else {
+    $Region = $env:AWS_DEFAULT_REGION
+    if (-not $Region) {
+        try {
+            $Region = aws configure get region 2>$null
+        } catch {
+            $Region = $null
+        }
+    }
+    
+    if (-not $Region) {
+        Write-ColorOutput "Error: AWS region not specified" -Color Red
+        Write-Host "Please provide -Region or set AWS_DEFAULT_REGION"
+        exit 1
+    }
+    
+    $env:AWS_REGION = $Region
+    $env:CDK_DEFAULT_REGION = $Region
+}
+Write-ColorOutput "Using AWS Region: $Region" -Color Yellow
+
+# Get AWS account ID
+try {
+    $AWS_ACCOUNT = aws sts get-caller-identity --query Account --output text 2>$null
+} catch {
+    $AWS_ACCOUNT = $null
+}
+
+if (-not $AWS_ACCOUNT) {
+    Write-ColorOutput "Error: Could not determine AWS account ID" -Color Red
+    exit 1
+}
+$env:CDK_DEFAULT_ACCOUNT = $AWS_ACCOUNT
+Write-ColorOutput "Using AWS Account: $AWS_ACCOUNT" -Color Yellow
+
+# Create output directory (use Windows temp and WSL paths)
+$outputDir = Join-Path $env:TEMP "graph-db-outputs"
+if (-not (Test-Path $outputDir)) {
+    New-Item -ItemType Directory -Path $outputDir -Force | Out-Null
+}
+
+# Also create WSL-compatible directory
+try {
+    wsl mkdir -p /tmp/graph-db-outputs 2>$null
+} catch {
+    # WSL not available
+}
+
+# Set CDK_DOCKER environment variable
+$env:CDK_DOCKER = "docker"
+
+# Build CDK deploy command
+$cdkArgs = @(
+    "deploy", "DataExplorerGraphDbStack"
+    "--app", "npx tsx bin/graph-db-app.ts"
+)
+
+# Add VPC context if provided
+if ($VpcId) {
+    Write-ColorOutput "Deploying to VPC: $VpcId" -Color Yellow
+    $cdkArgs += "--context", "vpcId=$VpcId"
+} else {
+    Write-ColorOutput "Deploying with new VPC" -Color Yellow
+}
+
+$cdkArgs += "--require-approval", "never"
+
+# Execute deployment
+if ($DryRun) {
+    Write-ColorOutput "[DRY RUN] Would execute:" -Color Blue
+    Write-Host "npx cdk $($cdkArgs -join ' ')"
+} else {
+    npx cdk @cdkArgs
+    
+    # Get deployment outputs
+    try {
+        $neptuneClusterId = aws cloudformation describe-stacks `
+            --stack-name DataExplorerGraphDbStack `
+            --query "Stacks[0].Outputs[?ExportName=='GraphDbNeptuneClusterId'].OutputValue" `
+            --output text 2>$null
+        
+        $neptuneEndpoint = aws cloudformation describe-stacks `
+            --stack-name DataExplorerGraphDbStack `
+            --query "Stacks[0].Outputs[?ExportName=='GraphDbNeptuneEndpoint'].OutputValue" `
+            --output text 2>$null
+        
+        $neptuneSgId = aws cloudformation describe-stacks `
+            --stack-name DataExplorerGraphDbStack `
+            --query "Stacks[0].Outputs[?ExportName=='GraphDbNeptuneSecurityGroupId'].OutputValue" `
+            --output text 2>$null
+        
+        $vpcIdOutput = aws cloudformation describe-stacks `
+            --stack-name DataExplorerGraphDbStack `
+            --query "Stacks[0].Outputs[?ExportName=='GraphDbVpcId'].OutputValue" `
+            --output text 2>$null
+        
+        Write-Host ""
+        Write-ColorOutput "🎉 Graph Database Stack Deployment Complete!" -Color Green
+        Write-Host "=============================================="
+        Write-Host "  📊 Neptune Cluster ID: $neptuneClusterId"
+        Write-Host "  🌐 Neptune Endpoint: $neptuneEndpoint"
+        Write-Host "  🔒 Neptune Security Group: $neptuneSgId"
+        Write-Host "  🏠 VPC ID: $vpcIdOutput"
+        Write-Host ""
+        
+        # Save outputs to Windows temp
+        $neptuneClusterId | Out-File -FilePath (Join-Path $outputDir "neptune-cluster-id.txt") -NoNewline -Encoding utf8
+        $neptuneEndpoint | Out-File -FilePath (Join-Path $outputDir "neptune-endpoint.txt") -NoNewline -Encoding utf8
+        $neptuneSgId | Out-File -FilePath (Join-Path $outputDir "neptune-sg-id.txt") -NoNewline -Encoding utf8
+        $vpcIdOutput | Out-File -FilePath (Join-Path $outputDir "vpc-id.txt") -NoNewline -Encoding utf8
+        
+        # Also save to WSL paths if available
+        try {
+            wsl bash -c "echo -n '$neptuneClusterId' > /tmp/graph-db-outputs/neptune-cluster-id.txt" 2>$null
+            wsl bash -c "echo -n '$neptuneEndpoint' > /tmp/graph-db-outputs/neptune-endpoint.txt" 2>$null
+            wsl bash -c "echo -n '$neptuneSgId' > /tmp/graph-db-outputs/neptune-sg-id.txt" 2>$null
+            wsl bash -c "echo -n '$vpcIdOutput' > /tmp/graph-db-outputs/vpc-id.txt" 2>$null
+        } catch {
+            # WSL not available
+        }
+        
+        Write-Host "Graph DB outputs saved to: $outputDir"
+    } catch {
+        Write-ColorOutput "Warning: Could not retrieve stack outputs" -Color Yellow
+    }
+}

--- a/dev-tools/deploy-graph-db.sh
+++ b/dev-tools/deploy-graph-db.sh
@@ -1,34 +1,65 @@
 #!/bin/bash
 
 # Deploy Graph Database Stack
-# Usage: ./deploy-graph-db.sh [--vpc-id vpc-xxxxx]
+# Usage: ./deploy-graph-db.sh [OPTIONS]
 
 set -e
 
+# Disable AWS CLI pager
+export AWS_PAGER=""
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
 # Default values
+AWS_PROFILE=""
+AWS_REGION=""
 VPC_ID=""
+DRY_RUN=false
 
 # Parse command line arguments
 while [[ $# -gt 0 ]]; do
   case $1 in
+    --profile)
+      AWS_PROFILE="$2"
+      shift 2
+      ;;
+    --region)
+      AWS_REGION="$2"
+      shift 2
+      ;;
     --vpc-id)
       VPC_ID="$2"
       shift 2
       ;;
+    --dry-run)
+      DRY_RUN=true
+      shift
+      ;;
     --help|-h)
+      echo -e "${BLUE}Deploy Graph Database Stack${NC}"
+      echo ""
       echo "Usage: $0 [OPTIONS]"
       echo ""
       echo "Options:"
+      echo "  --profile PROFILE       AWS CLI profile to use"
+      echo "  --region REGION         AWS region (e.g., us-east-1)"
       echo "  --vpc-id ID             Existing VPC ID (optional - creates new VPC if not provided)"
+      echo "  --dry-run               Show what would be deployed without deploying"
       echo "  --help, -h              Show this help message"
       echo ""
       echo "Examples:"
-      echo "  $0                      # Deploy with new VPC"
-      echo "  $0 --vpc-id vpc-123     # Deploy with existing VPC"
+      echo "  $0 --region us-east-1                    # Deploy with new VPC"
+      echo "  $0 --region us-east-1 --vpc-id vpc-123   # Deploy with existing VPC"
+      echo "  $0 --profile prod --region us-east-1    # Deploy with specific profile"
       exit 0
       ;;
     *)
-      echo "Unknown option: $1"
+      echo -e "${RED}Unknown option: $1${NC}"
       echo "Use --help for usage information"
       exit 1
       ;;
@@ -39,11 +70,39 @@ done
 PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$PROJECT_ROOT"
 
-echo "📊 Deploying Graph Database Stack..."
+echo -e "${BLUE}📊 Deploying Graph Database Stack...${NC}"
 
-# Set CDK environment variables
-export CDK_DEFAULT_ACCOUNT=$(aws sts get-caller-identity --query Account --output text)
-export CDK_DEFAULT_REGION=$(aws configure get region)
+# Set AWS profile if provided
+if [ -n "$AWS_PROFILE" ]; then
+    export AWS_PROFILE
+    echo -e "${YELLOW}Using AWS Profile: $AWS_PROFILE${NC}"
+fi
+
+# Set AWS region
+if [ -n "$AWS_REGION" ]; then
+    export AWS_REGION
+    export AWS_DEFAULT_REGION="$AWS_REGION"
+    export CDK_DEFAULT_REGION="$AWS_REGION"
+else
+    AWS_REGION="${AWS_DEFAULT_REGION:-$(aws configure get region 2>/dev/null || echo "")}"
+    if [ -z "$AWS_REGION" ]; then
+        echo -e "${RED}Error: AWS region not specified${NC}"
+        echo "Please provide --region or set AWS_DEFAULT_REGION"
+        exit 1
+    fi
+    export AWS_REGION
+    export CDK_DEFAULT_REGION="$AWS_REGION"
+fi
+echo -e "${YELLOW}Using AWS Region: $AWS_REGION${NC}"
+
+# Get AWS account ID
+AWS_ACCOUNT=$(aws sts get-caller-identity --query Account --output text 2>/dev/null || echo "")
+if [ -z "$AWS_ACCOUNT" ]; then
+    echo -e "${RED}Error: Could not determine AWS account ID${NC}"
+    exit 1
+fi
+export CDK_DEFAULT_ACCOUNT="$AWS_ACCOUNT"
+echo -e "${YELLOW}Using AWS Account: $AWS_ACCOUNT${NC}"
 
 # Create output directory
 mkdir -p /tmp/graph-db-outputs
@@ -53,36 +112,41 @@ CDK_COMMAND="CDK_DOCKER=podman npx cdk deploy DataExplorerGraphDbStack --app \"n
 
 # Add VPC context if provided
 if [ -n "$VPC_ID" ]; then
-  echo "** Deploying to VPC: $VPC_ID"
+  echo -e "${YELLOW}Deploying to VPC: $VPC_ID${NC}"
   CDK_COMMAND="$CDK_COMMAND --context vpcId=$VPC_ID"
 else
-  echo "** Deploying with new VPC"
+  echo -e "${YELLOW}Deploying with new VPC${NC}"
 fi
 
 CDK_COMMAND="$CDK_COMMAND --require-approval never"
 
 # Execute deployment
-eval $CDK_COMMAND
+if [ "$DRY_RUN" = true ]; then
+    echo -e "${BLUE}[DRY RUN] Would execute:${NC}"
+    echo "$CDK_COMMAND"
+else
+    eval $CDK_COMMAND
 
-# Get deployment outputs
-NEPTUNE_CLUSTER_ID=$(aws cloudformation describe-stacks --stack-name DataExplorerGraphDbStack --query "Stacks[0].Outputs[?ExportName=='GraphDbNeptuneClusterId'].OutputValue" --output text 2>/dev/null || echo "Not available")
-NEPTUNE_ENDPOINT=$(aws cloudformation describe-stacks --stack-name DataExplorerGraphDbStack --query "Stacks[0].Outputs[?ExportName=='GraphDbNeptuneEndpoint'].OutputValue" --output text 2>/dev/null || echo "Not available")
-NEPTUNE_SG_ID=$(aws cloudformation describe-stacks --stack-name DataExplorerGraphDbStack --query "Stacks[0].Outputs[?ExportName=='GraphDbNeptuneSecurityGroupId'].OutputValue" --output text 2>/dev/null || echo "Not available")
-VPC_ID_OUTPUT=$(aws cloudformation describe-stacks --stack-name DataExplorerGraphDbStack --query "Stacks[0].Outputs[?ExportName=='GraphDbVpcId'].OutputValue" --output text 2>/dev/null || echo "Not available")
+    # Get deployment outputs
+    NEPTUNE_CLUSTER_ID=$(aws cloudformation describe-stacks --stack-name DataExplorerGraphDbStack --query "Stacks[0].Outputs[?ExportName=='GraphDbNeptuneClusterId'].OutputValue" --output text 2>/dev/null || echo "Not available")
+    NEPTUNE_ENDPOINT=$(aws cloudformation describe-stacks --stack-name DataExplorerGraphDbStack --query "Stacks[0].Outputs[?ExportName=='GraphDbNeptuneEndpoint'].OutputValue" --output text 2>/dev/null || echo "Not available")
+    NEPTUNE_SG_ID=$(aws cloudformation describe-stacks --stack-name DataExplorerGraphDbStack --query "Stacks[0].Outputs[?ExportName=='GraphDbNeptuneSecurityGroupId'].OutputValue" --output text 2>/dev/null || echo "Not available")
+    VPC_ID_OUTPUT=$(aws cloudformation describe-stacks --stack-name DataExplorerGraphDbStack --query "Stacks[0].Outputs[?ExportName=='GraphDbVpcId'].OutputValue" --output text 2>/dev/null || echo "Not available")
 
-echo ""
-echo "🎉 Graph Database Stack Deployment Complete!"
-echo "=============================================="
-echo "  📊 Neptune Cluster ID: $NEPTUNE_CLUSTER_ID"
-echo "  🌐 Neptune Endpoint: $NEPTUNE_ENDPOINT"
-echo "  🔒 Neptune Security Group: $NEPTUNE_SG_ID"
-echo "  🏠 VPC ID: $VPC_ID_OUTPUT"
-echo ""
+    echo ""
+    echo -e "${GREEN}🎉 Graph Database Stack Deployment Complete!${NC}"
+    echo "=============================================="
+    echo "  📊 Neptune Cluster ID: $NEPTUNE_CLUSTER_ID"
+    echo "  🌐 Neptune Endpoint: $NEPTUNE_ENDPOINT"
+    echo "  🔒 Neptune Security Group: $NEPTUNE_SG_ID"
+    echo "  🏠 VPC ID: $VPC_ID_OUTPUT"
+    echo ""
 
-# Save outputs to files for main deployment script
-echo -n "$NEPTUNE_CLUSTER_ID" > /tmp/graph-db-outputs/neptune-cluster-id.txt
-echo -n "$NEPTUNE_ENDPOINT" > /tmp/graph-db-outputs/neptune-endpoint.txt
-echo -n "$NEPTUNE_SG_ID" > /tmp/graph-db-outputs/neptune-sg-id.txt
-echo -n "$VPC_ID_OUTPUT" > /tmp/graph-db-outputs/vpc-id.txt
+    # Save outputs to files for main deployment script
+    echo -n "$NEPTUNE_CLUSTER_ID" > /tmp/graph-db-outputs/neptune-cluster-id.txt
+    echo -n "$NEPTUNE_ENDPOINT" > /tmp/graph-db-outputs/neptune-endpoint.txt
+    echo -n "$NEPTUNE_SG_ID" > /tmp/graph-db-outputs/neptune-sg-id.txt
+    echo -n "$VPC_ID_OUTPUT" > /tmp/graph-db-outputs/vpc-id.txt
 
-echo "Graph DB outputs saved to /tmp/graph-db-outputs/"
+    echo "Graph DB outputs saved to /tmp/graph-db-outputs/"
+fi

--- a/dev-tools/deploy.ps1
+++ b/dev-tools/deploy.ps1
@@ -1,0 +1,520 @@
+<#
+.SYNOPSIS
+    Deploy AI Data Explorer to AWS (Windows PowerShell version)
+
+.DESCRIPTION
+    Enterprise-friendly deployment script with support for:
+    - Explicit AWS profile, region, and account
+    - Bring-your-own VPC, subnets, and security groups
+    - Dry-run mode for validation
+    - CDK bootstrap check (not auto-run)
+
+.PARAMETER Profile
+    AWS CLI profile to use
+
+.PARAMETER Region
+    AWS region (e.g., us-east-1)
+
+.PARAMETER Account
+    AWS account ID (optional, auto-detected if not provided)
+
+.PARAMETER VpcId
+    Existing VPC ID
+
+.PARAMETER PublicSubnetIds
+    Comma-separated public subnet IDs
+
+.PARAMETER PrivateSubnetIds
+    Comma-separated private subnet IDs
+
+.PARAMETER AlbSecurityGroupId
+    Security group ID for Application Load Balancer
+
+.PARAMETER EcsSecurityGroupId
+    Security group ID for ECS tasks
+
+.PARAMETER NeptuneSg
+    Neptune security group ID
+
+.PARAMETER NeptuneHost
+    Neptune cluster endpoint
+
+.PARAMETER WithGraphDb
+    Deploy Neptune graph database stack
+
+.PARAMETER GuardrailMode
+    'shadow' (monitor) or 'enforce' (block) - default: shadow
+
+.PARAMETER DryRun
+    Show what would be deployed without deploying
+
+.PARAMETER SkipBootstrapCheck
+    Skip CDK bootstrap verification
+
+.EXAMPLE
+    .\deploy.ps1 -Region us-east-1
+
+.EXAMPLE
+    .\deploy.ps1 -Profile my-profile -Region us-east-1
+
+.EXAMPLE
+    .\deploy.ps1 -Region us-east-1 -VpcId vpc-123 -PublicSubnetIds "subnet-pub1,subnet-pub2"
+#>
+
+[CmdletBinding()]
+param(
+    [string]$Profile,
+    [string]$Region,
+    [string]$Account,
+    [string]$VpcId,
+    [string]$PublicSubnetIds,
+    [string]$PrivateSubnetIds,
+    [string]$AlbSecurityGroupId,
+    [string]$EcsSecurityGroupId,
+    [string]$NeptuneSg,
+    [string]$NeptuneHost,
+    [switch]$WithGraphDb,
+    [ValidateSet("shadow", "enforce")]
+    [string]$GuardrailMode = "shadow",
+    [switch]$DryRun,
+    [switch]$SkipBootstrapCheck,
+    [switch]$Help
+)
+
+# Configuration
+$MIN_AWS_CLI_VERSION = "2.27.51"
+$APP_NAME = "ai-data-explorer"
+
+# Set error action preference
+$ErrorActionPreference = "Stop"
+
+# Function to compare version numbers
+function Compare-Version {
+    param([string]$Version1, [string]$Version2)
+    
+    $v1Parts = $Version1.Split('.')
+    $v2Parts = $Version2.Split('.')
+    
+    for ($i = 0; $i -lt 3; $i++) {
+        $v1Part = if ($i -lt $v1Parts.Length) { [int]$v1Parts[$i] } else { 0 }
+        $v2Part = if ($i -lt $v2Parts.Length) { [int]$v2Parts[$i] } else { 0 }
+        
+        if ($v1Part -gt $v2Part) { return 1 }
+        if ($v1Part -lt $v2Part) { return -1 }
+    }
+    return 0
+}
+
+# Function to write colored output
+function Write-ColorOutput {
+    param(
+        [string]$Message,
+        [string]$Color = "White"
+    )
+    Write-Host $Message -ForegroundColor $Color
+}
+
+# Show help
+if ($Help) {
+    Write-ColorOutput "AI Data Explorer - Deployment Script (PowerShell)" -Color Cyan
+    Write-Host ""
+    Write-Host "Usage: .\deploy.ps1 [OPTIONS]"
+    Write-Host ""
+    Write-ColorOutput "AWS Configuration:" -Color Yellow
+    Write-Host "  -Profile PROFILE       AWS CLI profile to use"
+    Write-Host "  -Region REGION         AWS region (e.g., us-east-1)"
+    Write-Host "  -Account ACCOUNT       AWS account ID (optional, auto-detected if not provided)"
+    Write-Host ""
+    Write-ColorOutput "VPC/Networking Options (for enterprise environments):" -Color Yellow
+    Write-Host "  -VpcId ID              Existing VPC ID"
+    Write-Host "  -PublicSubnetIds IDS   Comma-separated public subnet IDs"
+    Write-Host "  -PrivateSubnetIds IDS  Comma-separated private subnet IDs"
+    Write-Host "  -AlbSecurityGroupId ID Security group ID for Application Load Balancer"
+    Write-Host "  -EcsSecurityGroupId ID Security group ID for ECS tasks"
+    Write-Host ""
+    Write-ColorOutput "Neptune/Graph Database Options:" -Color Yellow
+    Write-Host "  -NeptuneSg ID          Neptune security group ID"
+    Write-Host "  -NeptuneHost HOST      Neptune cluster endpoint"
+    Write-Host "  -WithGraphDb           Deploy Neptune graph database stack"
+    Write-Host ""
+    Write-ColorOutput "Guardrails Options:" -Color Yellow
+    Write-Host "  -GuardrailMode MODE    'shadow' (monitor) or 'enforce' (block) - default: shadow"
+    Write-Host ""
+    Write-ColorOutput "Deployment Options:" -Color Yellow
+    Write-Host "  -DryRun                Show what would be deployed without deploying"
+    Write-Host "  -SkipBootstrapCheck    Skip CDK bootstrap verification"
+    Write-Host "  -Help                  Show this help message"
+    Write-Host ""
+    Write-ColorOutput "Examples:" -Color Yellow
+    Write-Host "  # Basic deployment (creates new VPC)"
+    Write-Host "  .\deploy.ps1 -Region us-east-1"
+    Write-Host ""
+    Write-Host "  # Deploy with specific AWS profile"
+    Write-Host "  .\deploy.ps1 -Profile my-profile -Region us-east-1"
+    Write-Host ""
+    Write-Host "  # Enterprise deployment with existing VPC and subnets"
+    Write-Host "  .\deploy.ps1 -Profile prod -Region us-east-1 ``"
+    Write-Host "     -VpcId vpc-123 ``"
+    Write-Host "     -PublicSubnetIds 'subnet-pub1,subnet-pub2' ``"
+    Write-Host "     -PrivateSubnetIds 'subnet-priv1,subnet-priv2'"
+    Write-Host ""
+    Write-ColorOutput "Required VPC Endpoints (for private subnet deployments):" -Color Yellow
+    Write-Host "  - com.amazonaws.<region>.ecr.api"
+    Write-Host "  - com.amazonaws.<region>.ecr.dkr"
+    Write-Host "  - com.amazonaws.<region>.s3 (Gateway)"
+    Write-Host "  - com.amazonaws.<region>.logs"
+    Write-Host "  - com.amazonaws.<region>.secretsmanager"
+    Write-Host "  - com.amazonaws.<region>.bedrock-runtime"
+    Write-Host "  - com.amazonaws.<region>.bedrock-agent-runtime"
+    Write-Host "  - com.amazonaws.<region>.sts"
+    Write-Host "  - com.amazonaws.<region>.xray"
+    Write-Host ""
+    exit 0
+}
+
+# Banner
+Write-Host ""
+Write-ColorOutput "╔════════════════════════════════════════════════════════════╗" -Color Cyan
+Write-ColorOutput "║          AI Data Explorer - Deployment (PowerShell)        ║" -Color Cyan
+Write-ColorOutput "╚════════════════════════════════════════════════════════════╝" -Color Cyan
+Write-Host ""
+
+# Disable AWS CLI pager
+$env:AWS_PAGER = ""
+
+# Set AWS profile if provided
+if ($Profile) {
+    $env:AWS_PROFILE = $Profile
+    Write-ColorOutput "Using AWS Profile: $Profile" -Color Yellow
+}
+
+# Set AWS region
+if ($Region) {
+    $env:AWS_REGION = $Region
+    $env:AWS_DEFAULT_REGION = $Region
+    $env:CDK_DEFAULT_REGION = $Region
+    Write-ColorOutput "Using AWS Region: $Region" -Color Yellow
+} else {
+    # Try to get region from profile or environment
+    $Region = $env:AWS_DEFAULT_REGION
+    if (-not $Region) {
+        try {
+            $Region = aws configure get region 2>$null
+        } catch {
+            $Region = $null
+        }
+    }
+    
+    if (-not $Region) {
+        Write-ColorOutput "Error: AWS region not specified and could not be auto-detected" -Color Red
+        Write-Host "Please provide -Region or set AWS_DEFAULT_REGION"
+        exit 1
+    }
+    
+    $env:AWS_REGION = $Region
+    $env:CDK_DEFAULT_REGION = $Region
+    Write-ColorOutput "Auto-detected AWS Region: $Region" -Color Yellow
+}
+
+# Set embedding model ARN with region
+$env:EMBEDDING_MODEL = "arn:aws:bedrock:${Region}::foundation-model/amazon.titan-embed-text-v2:0"
+$env:APP_NAME = $APP_NAME
+
+# Get or validate AWS account ID
+if ($Account) {
+    $env:CDK_DEFAULT_ACCOUNT = $Account
+    Write-ColorOutput "Using AWS Account: $Account" -Color Yellow
+} else {
+    try {
+        $Account = aws sts get-caller-identity --query Account --output text 2>$null
+    } catch {
+        $Account = $null
+    }
+    
+    if (-not $Account) {
+        Write-ColorOutput "Error: Could not determine AWS account ID" -Color Red
+        Write-Host "Please provide -Account or ensure AWS credentials are configured"
+        exit 1
+    }
+    
+    $env:CDK_DEFAULT_ACCOUNT = $Account
+    Write-ColorOutput "Auto-detected AWS Account: $Account" -Color Yellow
+}
+
+# Preflight check: AWS CLI version
+Write-Host ""
+Write-ColorOutput "Checking prerequisites..." -Color Blue
+
+$awsCommand = Get-Command aws -ErrorAction SilentlyContinue
+if (-not $awsCommand) {
+    Write-ColorOutput "❌ Error: AWS CLI is not installed or not in PATH" -Color Red
+    Write-Host "📣 Please install AWS CLI version $MIN_AWS_CLI_VERSION or later"
+    exit 1
+}
+
+$awsVersionOutput = aws --version 2>&1
+$awsVersion = ($awsVersionOutput -split '/')[1] -split ' ' | Select-Object -First 1
+
+if ((Compare-Version $awsVersion $MIN_AWS_CLI_VERSION) -lt 0) {
+    Write-ColorOutput "❌ Error: AWS CLI version $awsVersion is below minimum required version $MIN_AWS_CLI_VERSION" -Color Red
+    Write-Host "📣 Please upgrade your AWS CLI to version $MIN_AWS_CLI_VERSION or later"
+    exit 1
+}
+Write-ColorOutput "✓ AWS CLI version $awsVersion" -Color Green
+
+# Check CDK bootstrap status
+if (-not $SkipBootstrapCheck) {
+    Write-ColorOutput "Checking CDK bootstrap status..." -Color Blue
+    
+    try {
+        $bootstrapStack = aws cloudformation describe-stacks `
+            --stack-name CDKToolkit `
+            --region $Region `
+            --query 'Stacks[0].StackStatus' `
+            --output text 2>$null
+    } catch {
+        $bootstrapStack = "NOT_FOUND"
+    }
+    
+    if (-not $bootstrapStack -or $bootstrapStack -eq "NOT_FOUND") {
+        Write-ColorOutput "❌ CDK is not bootstrapped in $Region" -Color Red
+        Write-Host ""
+        Write-Host "Please run the following command first:"
+        Write-ColorOutput "  npx cdk bootstrap aws://$Account/$Region" -Color Yellow
+        Write-Host ""
+        Write-Host "Or use -SkipBootstrapCheck to bypass this verification"
+        exit 1
+    } else {
+        Write-ColorOutput "✓ CDK bootstrapped in $Region" -Color Green
+    }
+}
+
+# Display configuration
+Write-Host ""
+Write-ColorOutput "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━" -Color Blue
+Write-ColorOutput "Configuration Summary" -Color Blue
+Write-ColorOutput "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━" -Color Blue
+Write-Host "  AWS Account:    $Account"
+Write-Host "  AWS Region:     $Region"
+if ($Profile) { Write-Host "  AWS Profile:    $Profile" }
+Write-Host "  Dry Run:        $DryRun"
+Write-Host ""
+Write-Host "  VPC:"
+if ($VpcId) {
+    Write-Host "    VPC ID:              $VpcId"
+    if ($PublicSubnetIds) { Write-Host "    Public Subnets:      $PublicSubnetIds" }
+    if ($PrivateSubnetIds) { Write-Host "    Private Subnets:     $PrivateSubnetIds" }
+    if ($AlbSecurityGroupId) { Write-Host "    ALB Security Group:  $AlbSecurityGroupId" }
+    if ($EcsSecurityGroupId) { Write-Host "    ECS Security Group:  $EcsSecurityGroupId" }
+} else {
+    Write-Host "    Creating new VPC"
+}
+Write-Host ""
+Write-Host "  Guardrails:     $GuardrailMode"
+Write-Host "  Graph DB:       $WithGraphDb"
+if ($NeptuneHost) { Write-Host "  Neptune Host:   $NeptuneHost" }
+Write-Host ""
+
+if ($DryRun) {
+    Write-ColorOutput "DRY RUN MODE - No resources will be deployed" -Color Cyan
+    Write-Host ""
+}
+
+# Validate Neptune configuration
+if ($NeptuneHost -and -not $NeptuneSg) {
+    Write-ColorOutput "Error: When using Neptune host, -NeptuneSg is also required" -Color Red
+    exit 1
+}
+
+# Get project root (script is in dev-tools folder)
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$ProjectRoot = Split-Path -Parent $ScriptDir
+Set-Location $ProjectRoot
+
+# Update version information before deployment
+if (-not $DryRun) {
+    Write-Host "Updating version information..."
+    npm run version:update
+}
+
+# Deploy Graph Database Stack if requested
+if ($WithGraphDb) {
+    Write-ColorOutput "Deploying Graph Database Stack..." -Color Blue
+    
+    $graphArgs = @()
+    if ($VpcId) { $graphArgs += "--vpc-id", $VpcId }
+    if ($Profile) { $graphArgs += "--profile", $Profile }
+    if ($Region) { $graphArgs += "--region", $Region }
+    
+    if ($DryRun) {
+        Write-ColorOutput "[DRY RUN] Would run: .\dev-tools\deploy-graph-db.ps1 $($graphArgs -join ' ')" -Color Cyan
+    } else {
+        # Check if PowerShell version exists, otherwise use bash via WSL
+        $graphDbScript = Join-Path $ProjectRoot "dev-tools\deploy-graph-db.ps1"
+        if (Test-Path $graphDbScript) {
+            & $graphDbScript @graphArgs
+        } else {
+            Write-ColorOutput "Note: Using WSL to run deploy-graph-db.sh" -Color Yellow
+            $bashArgs = $graphArgs -join ' '
+            wsl bash -c "./dev-tools/deploy-graph-db.sh $bashArgs"
+        }
+        
+        # Read Neptune outputs for main deployment
+        $neptuneEndpointFile = "/tmp/graph-db-outputs/neptune-endpoint.txt"
+        $neptuneSgFile = "/tmp/graph-db-outputs/neptune-sg-id.txt"
+        $vpcIdFile = "/tmp/graph-db-outputs/vpc-id.txt"
+        
+        # Try to read from WSL paths
+        try {
+            $NeptuneHost = wsl cat $neptuneEndpointFile 2>$null
+            $NeptuneSg = wsl cat $neptuneSgFile 2>$null
+            if (-not $VpcId) {
+                $VpcId = wsl cat $vpcIdFile 2>$null
+            }
+            if ($NeptuneHost) {
+                Write-Host "Using deployed Neptune: $NeptuneHost (SG: $NeptuneSg)"
+            }
+        } catch {
+            Write-ColorOutput "Warning: Could not read Neptune outputs" -Color Yellow
+        }
+    }
+}
+
+# Check for existing Neptune stack
+if (-not $NeptuneHost -and -not $NeptuneSg -and -not $DryRun) {
+    Write-Host "Checking for existing Neptune stack..."
+    
+    try {
+        $existingNeptuneHost = aws cloudformation describe-stacks `
+            --stack-name DataExplorerGraphDbStack `
+            --query "Stacks[0].Outputs[?ExportName=='GraphDbNeptuneEndpoint'].OutputValue" `
+            --output text 2>$null
+        
+        $existingNeptuneSg = aws cloudformation describe-stacks `
+            --stack-name DataExplorerGraphDbStack `
+            --query "Stacks[0].Outputs[?ExportName=='GraphDbNeptuneSecurityGroupId'].OutputValue" `
+            --output text 2>$null
+        
+        $existingVpcId = aws cloudformation describe-stacks `
+            --stack-name DataExplorerGraphDbStack `
+            --query "Stacks[0].Outputs[?ExportName=='GraphDbVpcId'].OutputValue" `
+            --output text 2>$null
+        
+        if ($existingNeptuneHost -and $existingNeptuneSg -and $existingNeptuneHost -ne "None") {
+            $NeptuneHost = $existingNeptuneHost
+            $NeptuneSg = $existingNeptuneSg
+            if (-not $VpcId -and $existingVpcId) {
+                $VpcId = $existingVpcId
+            }
+            Write-ColorOutput "Found existing Neptune stack" -Color Green
+        }
+    } catch {
+        # No existing Neptune stack
+    }
+}
+
+# Create Knowledge Base
+if (-not $DryRun) {
+    Write-ColorOutput "Creating Bedrock Knowledge Bases..." -Color Blue
+    
+    # Check if PowerShell version exists, otherwise use bash via WSL
+    $kbCreateScript = Join-Path $ProjectRoot "scripts\kb-create.ps1"
+    if (Test-Path $kbCreateScript) {
+        & $kbCreateScript
+    } else {
+        Write-ColorOutput "Note: Using WSL to run kb-create.sh" -Color Yellow
+        wsl bash -c "./scripts/kb-create.sh"
+    }
+    
+    # Read KB outputs
+    try {
+        $HelpKbId = wsl cat /tmp/kb-outputs/help-kb-id.txt 2>$null
+        $ProductsKbId = wsl cat /tmp/kb-outputs/products-kb-id.txt 2>$null
+        $TariffsKbId = wsl cat /tmp/kb-outputs/tariffs-kb-id.txt 2>$null
+        
+        if ($HelpKbId) { Write-ColorOutput "✓ Help Knowledge Base: $HelpKbId" -Color Green }
+        if ($ProductsKbId) { Write-ColorOutput "✓ Products Knowledge Base: $ProductsKbId" -Color Green }
+        if ($TariffsKbId) { Write-ColorOutput "✓ Tariffs Knowledge Base: $TariffsKbId" -Color Green }
+    } catch {
+        Write-ColorOutput "Warning: Could not read KB outputs" -Color Yellow
+    }
+} else {
+    Write-ColorOutput "[DRY RUN] Would create Bedrock Knowledge Bases" -Color Cyan
+}
+
+# Build CDK command
+Write-Host ""
+Write-ColorOutput "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━" -Color Blue
+Write-ColorOutput "Deploying CDK Stack" -Color Blue
+Write-ColorOutput "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━" -Color Blue
+
+# Set CDK_DOCKER environment variable (use docker on Windows)
+$env:CDK_DOCKER = "docker"
+
+$cdkArgs = @(
+    "deploy"
+    "--app", "npx tsx bin/cdk-app.ts"
+)
+
+# Add VPC context
+if ($VpcId) { $cdkArgs += "--context", "vpcId=$VpcId" }
+if ($PublicSubnetIds) { $cdkArgs += "--context", "publicSubnetIds=$PublicSubnetIds" }
+if ($PrivateSubnetIds) { $cdkArgs += "--context", "privateSubnetIds=$PrivateSubnetIds" }
+if ($AlbSecurityGroupId) { $cdkArgs += "--context", "albSecurityGroupId=$AlbSecurityGroupId" }
+if ($EcsSecurityGroupId) { $cdkArgs += "--context", "ecsSecurityGroupId=$EcsSecurityGroupId" }
+
+# Add Neptune context
+if ($NeptuneHost) {
+    $cdkArgs += "--context", "withGraphDb=true"
+    $cdkArgs += "--context", "neptuneHost=$NeptuneHost"
+    $cdkArgs += "--context", "neptuneSgId=$NeptuneSg"
+}
+
+# Add guardrails context
+$cdkArgs += "--context", "guardrailMode=$GuardrailMode"
+$cdkArgs += "--require-approval", "never"
+
+# Execute deployment
+if ($DryRun) {
+    Write-ColorOutput "[DRY RUN] Would execute:" -Color Cyan
+    Write-Host "npx cdk $($cdkArgs -join ' ')"
+    Write-Host ""
+    Write-ColorOutput "[DRY RUN] Synthesizing templates to validate..." -Color Cyan
+    
+    try {
+        npx cdk synth --app "npx tsx bin/cdk-app.ts" --quiet
+    } catch {
+        # Ignore synth errors in dry run
+    }
+    
+    Write-ColorOutput "✓ Dry run completed" -Color Green
+} else {
+    npx cdk @cdkArgs
+}
+
+# Show deployment summary
+Write-Host ""
+Write-ColorOutput "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━" -Color Green
+Write-ColorOutput "Deployment Complete!" -Color Green
+Write-ColorOutput "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━" -Color Green
+
+if (-not $DryRun) {
+    try {
+        $albUrl = aws cloudformation describe-stacks `
+            --stack-name DataExplorerAgentsStack `
+            --query "Stacks[0].Outputs[?ExportName=='ALBEndpoint'].OutputValue" `
+            --output text 2>$null
+        
+        $cloudfrontUrl = aws cloudformation describe-stacks `
+            --stack-name DataExplorerAgentsStack `
+            --query "Stacks[0].Outputs[?ExportName=='ApplicationUrl'].OutputValue" `
+            --output text 2>$null
+        
+        Write-Host ""
+        Write-Host "  CloudFront URL (HTTPS): $cloudfrontUrl"
+    } catch {
+        Write-Host "  URLs not available yet"
+    }
+}
+
+Write-Host ""

--- a/dev-tools/deploy.sh
+++ b/dev-tools/deploy.sh
@@ -2,80 +2,104 @@
 
 # Deploy AI Data Explorer with optional VPC/Neptune and Bedrock Guardrails
 # Usage: ./deploy.sh [OPTIONS]
+#
+# Enterprise-friendly deployment script with support for:
+# - Explicit AWS profile, region, and account
+# - Bring-your-own VPC, subnets, and security groups
+# - Dry-run mode for validation
+# - CDK bootstrap check (not auto-run)
 
 set -e
 
+# Disable AWS CLI pager
+export AWS_PAGER=""
+
 # Configuration
-# Required s3vectors support was added in this version
 MIN_AWS_CLI_VERSION="2.27.51"
 
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+NC='\033[0m' # No Color
 
 # Function to compare version numbers
 version_compare() {
     local version1=$1
     local version2=$2
-    
-    # Split versions into arrays
     IFS='.' read -ra V1 <<< "$version1"
     IFS='.' read -ra V2 <<< "$version2"
-    
-    # Compare each part
     for i in {0..2}; do
         local v1_part=${V1[i]:-0}
         local v2_part=${V2[i]:-0}
-        
         if (( v1_part > v2_part )); then
-            return 0  # version1 > version2
+            return 0
         elif (( v1_part < v2_part )); then
-            return 1  # version1 < version2
+            return 1
         fi
     done
-    
-    return 0  # versions are equal
+    return 0
 }
 
-# Preflight check: AWS CLI version
-echo "Checking AWS CLI version..."
-if ! command -v aws &> /dev/null; then
-    echo "❌ Error: AWS CLI is not installed or not in PATH"
-    echo "📣 Please install AWS CLI version $MIN_AWS_CLI_VERSION or later"
-    exit 1
-fi
-
-AWS_VERSION=$(aws --version 2>&1 | cut -d/ -f2 | cut -d' ' -f1)
-echo "Found AWS CLI version: $AWS_VERSION"
-
-if ! version_compare "$AWS_VERSION" "$MIN_AWS_CLI_VERSION"; then
-    echo "❌ Error: AWS CLI version $AWS_VERSION is below minimum required version $MIN_AWS_CLI_VERSION"
-    echo "📣 Please upgrade your AWS CLI to version $MIN_AWS_CLI_VERSION or later"
-    echo "⚙️  Visit: https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html"
-    exit 1
-fi
-
-echo "✓ AWS CLI version check passed"
-
-# Update version information before deployment
-echo "Updating version information..."
-npm run version:update
-
 # Default values
+AWS_PROFILE=""
+AWS_REGION=""
+AWS_ACCOUNT=""
 VPC_ID=""
+PUBLIC_SUBNET_IDS=""
+PRIVATE_SUBNET_IDS=""
+ALB_SECURITY_GROUP_ID=""
+ECS_SECURITY_GROUP_ID=""
 NEPTUNE_SG=""
 NEPTUNE_HOST=""
-GUARDRAIL_MODE=""
+GUARDRAIL_MODE="shadow"
 DEPLOY_GRAPH_DB=false
+DRY_RUN=false
+SKIP_BOOTSTRAP_CHECK=false
 
 # Knowledge Base configuration
 export APP_NAME="ai-data-explorer"
-export EMBEDDING_MODEL="arn:aws:bedrock:${AWS_REGION}::foundation-model/amazon.titan-embed-text-v2:0"
 
 # Parse command line arguments
 while [[ $# -gt 0 ]]; do
   case $1 in
+    # AWS Configuration
+    --profile)
+      AWS_PROFILE="$2"
+      shift 2
+      ;;
+    --region)
+      AWS_REGION="$2"
+      shift 2
+      ;;
+    --account)
+      AWS_ACCOUNT="$2"
+      shift 2
+      ;;
+    # VPC/Networking Options
     --vpc-id)
       VPC_ID="$2"
       shift 2
       ;;
+    --public-subnet-ids)
+      PUBLIC_SUBNET_IDS="$2"
+      shift 2
+      ;;
+    --private-subnet-ids)
+      PRIVATE_SUBNET_IDS="$2"
+      shift 2
+      ;;
+    --alb-security-group-id)
+      ALB_SECURITY_GROUP_ID="$2"
+      shift 2
+      ;;
+    --ecs-security-group-id)
+      ECS_SECURITY_GROUP_ID="$2"
+      shift 2
+      ;;
+    # Neptune Options
     --neptune-sg)
       NEPTUNE_SG="$2"
       shift 2
@@ -84,197 +108,336 @@ while [[ $# -gt 0 ]]; do
       NEPTUNE_HOST="$2"
       shift 2
       ;;
-    --guardrail-mode)
-      GUARDRAIL_MODE="$2"
-      shift 2
-      ;;
     --with-graph-db)
       DEPLOY_GRAPH_DB=true
       shift
       ;;
+    # Guardrails Options
+    --guardrail-mode)
+      GUARDRAIL_MODE="$2"
+      shift 2
+      ;;
+    # Deployment Options
+    --dry-run)
+      DRY_RUN=true
+      shift
+      ;;
+    --skip-bootstrap-check)
+      SKIP_BOOTSTRAP_CHECK=true
+      shift
+      ;;
     --help|-h)
+      echo -e "${CYAN}AI Data Explorer - Deployment Script${NC}"
+      echo ""
       echo "Usage: $0 [OPTIONS]"
       echo ""
-      echo "VPC/Neptune Options:"
-      echo "  --vpc-id ID             Existing VPC ID (optional - creates new VPC if not provided)"
-      echo "  --neptune-sg ID         Neptune security group ID (required if using existing VPC)"
-      echo "  --neptune-host HOST     Neptune cluster endpoint (required if using existing VPC)"
+      echo -e "${YELLOW}AWS Configuration:${NC}"
+      echo "  --profile PROFILE       AWS CLI profile to use"
+      echo "  --region REGION         AWS region (e.g., us-east-1)"
+      echo "  --account ACCOUNT       AWS account ID (optional, auto-detected if not provided)"
       echo ""
-      echo "Guardrails Options:"
-      echo "  --guardrail-mode MODE   'shadow' (monitor) or 'enforce' (block) - default: shadow"
+      echo -e "${YELLOW}VPC/Networking Options (for enterprise environments):${NC}"
+      echo "  --vpc-id ID             Existing VPC ID"
+      echo "  --public-subnet-ids IDS Comma-separated public subnet IDs (e.g., subnet-a,subnet-b)"
+      echo "  --private-subnet-ids IDS Comma-separated private subnet IDs (e.g., subnet-c,subnet-d)"
+      echo "  --alb-security-group-id ID  Security group ID for Application Load Balancer"
+      echo "  --ecs-security-group-id ID  Security group ID for ECS tasks"
       echo ""
-      echo "Graph Database Options:"
+      echo -e "${YELLOW}Neptune/Graph Database Options:${NC}"
+      echo "  --neptune-sg ID         Neptune security group ID"
+      echo "  --neptune-host HOST     Neptune cluster endpoint"
       echo "  --with-graph-db         Deploy Neptune graph database stack"
       echo ""
-      echo "General Options:"
+      echo -e "${YELLOW}Guardrails Options:${NC}"
+      echo "  --guardrail-mode MODE   'shadow' (monitor) or 'enforce' (block) - default: shadow"
+      echo ""
+      echo -e "${YELLOW}Deployment Options:${NC}"
+      echo "  --dry-run               Show what would be deployed without deploying"
+      echo "  --skip-bootstrap-check  Skip CDK bootstrap verification"
       echo "  --help, -h              Show this help message"
       echo ""
-      echo "Examples:"
-      echo "  $0                                    # Deploy with new VPC, shadow guardrails"
-      echo "  $0 --guardrail-mode enforce          # Deploy with new VPC, enforcing guardrails"
-      echo "  $0 --vpc-id vpc-123 --neptune-sg sg-456 --neptune-host cluster.neptune.amazonaws.com"
+      echo -e "${YELLOW}Examples:${NC}"
+      echo "  # Basic deployment (creates new VPC)"
+      echo "  $0 --region us-east-1"
+      echo ""
+      echo "  # Deploy with specific AWS profile"
+      echo "  $0 --profile my-profile --region us-east-1"
+      echo ""
+      echo "  # Enterprise deployment with existing VPC and subnets"
+      echo "  $0 --profile prod --region us-east-1 \\"
+      echo "     --vpc-id vpc-123 \\"
+      echo "     --public-subnet-ids subnet-pub1,subnet-pub2 \\"
+      echo "     --private-subnet-ids subnet-priv1,subnet-priv2"
+      echo ""
+      echo "  # Full enterprise deployment with all pre-created resources"
+      echo "  $0 --profile prod --region us-east-1 \\"
+      echo "     --vpc-id vpc-123 \\"
+      echo "     --public-subnet-ids subnet-pub1,subnet-pub2 \\"
+      echo "     --private-subnet-ids subnet-priv1,subnet-priv2 \\"
+      echo "     --alb-security-group-id sg-alb \\"
+      echo "     --ecs-security-group-id sg-ecs"
+      echo ""
+      echo -e "${YELLOW}Required VPC Endpoints (for private subnet deployments):${NC}"
+      echo "  - com.amazonaws.<region>.ecr.api"
+      echo "  - com.amazonaws.<region>.ecr.dkr"
+      echo "  - com.amazonaws.<region>.s3 (Gateway)"
+      echo "  - com.amazonaws.<region>.logs"
+      echo "  - com.amazonaws.<region>.secretsmanager"
+      echo "  - com.amazonaws.<region>.bedrock-runtime"
+      echo "  - com.amazonaws.<region>.bedrock-agent-runtime"
+      echo "  - com.amazonaws.<region>.sts"
+      echo "  - com.amazonaws.<region>.xray"
+      echo ""
       exit 0
       ;;
     *)
-      echo "Unknown option: $1"
+      echo -e "${RED}Unknown option: $1${NC}"
       echo "Use --help for usage information"
       exit 1
       ;;
   esac
 done
 
+echo -e "${CYAN}╔════════════════════════════════════════════════════════════╗${NC}"
+echo -e "${CYAN}║          AI Data Explorer - Deployment                     ║${NC}"
+echo -e "${CYAN}╚════════════════════════════════════════════════════════════╝${NC}"
+echo ""
+
+# Set AWS profile if provided
+if [ -n "$AWS_PROFILE" ]; then
+    export AWS_PROFILE
+    echo -e "${YELLOW}Using AWS Profile: $AWS_PROFILE${NC}"
+fi
+
+# Set AWS region if provided
+if [ -n "$AWS_REGION" ]; then
+    export AWS_REGION
+    export AWS_DEFAULT_REGION="$AWS_REGION"
+    export CDK_DEFAULT_REGION="$AWS_REGION"
+    echo -e "${YELLOW}Using AWS Region: $AWS_REGION${NC}"
+else
+    # Try to get region from profile or environment
+    AWS_REGION="${AWS_DEFAULT_REGION:-$(aws configure get region 2>/dev/null || echo "")}"
+    if [ -z "$AWS_REGION" ]; then
+        echo -e "${RED}Error: AWS region not specified and could not be auto-detected${NC}"
+        echo "Please provide --region or set AWS_DEFAULT_REGION"
+        exit 1
+    fi
+    export AWS_REGION
+    export CDK_DEFAULT_REGION="$AWS_REGION"
+    echo -e "${YELLOW}Auto-detected AWS Region: $AWS_REGION${NC}"
+fi
+
+# Set embedding model ARN with region
+export EMBEDDING_MODEL="arn:aws:bedrock:${AWS_REGION}::foundation-model/amazon.titan-embed-text-v2:0"
+
+# Get or validate AWS account ID
+if [ -n "$AWS_ACCOUNT" ]; then
+    export CDK_DEFAULT_ACCOUNT="$AWS_ACCOUNT"
+    echo -e "${YELLOW}Using AWS Account: $AWS_ACCOUNT${NC}"
+else
+    AWS_ACCOUNT=$(aws sts get-caller-identity --query Account --output text 2>/dev/null || echo "")
+    if [ -z "$AWS_ACCOUNT" ]; then
+        echo -e "${RED}Error: Could not determine AWS account ID${NC}"
+        echo "Please provide --account or ensure AWS credentials are configured"
+        exit 1
+    fi
+    export CDK_DEFAULT_ACCOUNT="$AWS_ACCOUNT"
+    echo -e "${YELLOW}Auto-detected AWS Account: $AWS_ACCOUNT${NC}"
+fi
+
+# Preflight check: AWS CLI version
+echo ""
+echo -e "${BLUE}Checking prerequisites...${NC}"
+if ! command -v aws &> /dev/null; then
+    echo -e "${RED}❌ Error: AWS CLI is not installed or not in PATH${NC}"
+    echo "📣 Please install AWS CLI version $MIN_AWS_CLI_VERSION or later"
+    exit 1
+fi
+
+AWS_VERSION=$(aws --version 2>&1 | cut -d/ -f2 | cut -d' ' -f1)
+if ! version_compare "$AWS_VERSION" "$MIN_AWS_CLI_VERSION"; then
+    echo -e "${RED}❌ Error: AWS CLI version $AWS_VERSION is below minimum required version $MIN_AWS_CLI_VERSION${NC}"
+    echo "📣 Please upgrade your AWS CLI to version $MIN_AWS_CLI_VERSION or later"
+    exit 1
+fi
+echo -e "${GREEN}✓ AWS CLI version $AWS_VERSION${NC}"
+
+# Check CDK bootstrap status
+if [ "$SKIP_BOOTSTRAP_CHECK" != true ]; then
+    echo -e "${BLUE}Checking CDK bootstrap status...${NC}"
+    BOOTSTRAP_STACK=$(aws cloudformation describe-stacks \
+        --stack-name CDKToolkit \
+        --region "$AWS_REGION" \
+        --query 'Stacks[0].StackStatus' \
+        --output text 2>/dev/null || echo "NOT_FOUND")
+    
+    if [ "$BOOTSTRAP_STACK" = "NOT_FOUND" ]; then
+        echo -e "${RED}❌ CDK is not bootstrapped in $AWS_REGION${NC}"
+        echo ""
+        echo "Please run the following command first:"
+        echo -e "${YELLOW}  npx cdk bootstrap aws://$AWS_ACCOUNT/$AWS_REGION${NC}"
+        echo ""
+        echo "Or use --skip-bootstrap-check to bypass this verification"
+        exit 1
+    else
+        echo -e "${GREEN}✓ CDK bootstrapped in $AWS_REGION${NC}"
+    fi
+fi
+
+# Display configuration
+echo ""
+echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo -e "${BLUE}Configuration Summary${NC}"
+echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo "  AWS Account:    $AWS_ACCOUNT"
+echo "  AWS Region:     $AWS_REGION"
+[ -n "$AWS_PROFILE" ] && echo "  AWS Profile:    $AWS_PROFILE"
+echo "  Dry Run:        $DRY_RUN"
+echo ""
+echo "  VPC:"
+if [ -n "$VPC_ID" ]; then
+    echo "    VPC ID:              $VPC_ID"
+    [ -n "$PUBLIC_SUBNET_IDS" ] && echo "    Public Subnets:      $PUBLIC_SUBNET_IDS"
+    [ -n "$PRIVATE_SUBNET_IDS" ] && echo "    Private Subnets:     $PRIVATE_SUBNET_IDS"
+    [ -n "$ALB_SECURITY_GROUP_ID" ] && echo "    ALB Security Group:  $ALB_SECURITY_GROUP_ID"
+    [ -n "$ECS_SECURITY_GROUP_ID" ] && echo "    ECS Security Group:  $ECS_SECURITY_GROUP_ID"
+else
+    echo "    Creating new VPC"
+fi
+echo ""
+echo "  Guardrails:     $GUARDRAIL_MODE"
+echo "  Graph DB:       $DEPLOY_GRAPH_DB"
+[ -n "$NEPTUNE_HOST" ] && echo "  Neptune Host:   $NEPTUNE_HOST"
+echo ""
+
+if [ "$DRY_RUN" = true ]; then
+    echo -e "${CYAN}DRY RUN MODE - No resources will be deployed${NC}"
+    echo ""
+fi
+
 # Validate Neptune configuration
 if [ -n "$NEPTUNE_HOST" ]; then
-  if [ -z "$NEPTUNE_SG" ]; then
-    echo "Error: When using Neptune host, --neptune-sg is also required"
-    echo "Use --help for usage information"
-    exit 1
-  fi
+    if [ -z "$NEPTUNE_SG" ]; then
+        echo -e "${RED}Error: When using Neptune host, --neptune-sg is also required${NC}"
+        exit 1
+    fi
 fi
 
 # Build CDK deploy command (stay in project root)
 PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$PROJECT_ROOT"
 
+# Update version information before deployment
+if [ "$DRY_RUN" != true ]; then
+    echo "Updating version information..."
+    npm run version:update
+fi
+
 # Deploy Graph Database Stack if requested
 if [ "$DEPLOY_GRAPH_DB" = true ]; then
-  if [ -n "$VPC_ID" ]; then
-    ./dev-tools/deploy-graph-db.sh --vpc-id "$VPC_ID"
-  else
-    ./dev-tools/deploy-graph-db.sh
-  fi
-  
-  # Read Neptune outputs for main deployment
-  if [ -f "/tmp/graph-db-outputs/neptune-endpoint.txt" ] && [ -f "/tmp/graph-db-outputs/neptune-sg-id.txt" ]; then
-    NEPTUNE_HOST=$(cat /tmp/graph-db-outputs/neptune-endpoint.txt)
-    NEPTUNE_SG=$(cat /tmp/graph-db-outputs/neptune-sg-id.txt)
+    echo -e "${BLUE}Deploying Graph Database Stack...${NC}"
+    GRAPH_ARGS=""
+    [ -n "$VPC_ID" ] && GRAPH_ARGS="$GRAPH_ARGS --vpc-id $VPC_ID"
+    [ -n "$AWS_PROFILE" ] && GRAPH_ARGS="$GRAPH_ARGS --profile $AWS_PROFILE"
+    [ -n "$AWS_REGION" ] && GRAPH_ARGS="$GRAPH_ARGS --region $AWS_REGION"
     
-    # Read VPC ID if not already set and file exists
-    if [ -z "$VPC_ID" ] && [ -f "/tmp/graph-db-outputs/vpc-id.txt" ]; then
-      VPC_ID=$(cat /tmp/graph-db-outputs/vpc-id.txt)
-      echo "Using deployed VPC: $VPC_ID"
+    if [ "$DRY_RUN" = true ]; then
+        echo -e "${CYAN}[DRY RUN] Would run: ./dev-tools/deploy-graph-db.sh $GRAPH_ARGS${NC}"
+    else
+        ./dev-tools/deploy-graph-db.sh $GRAPH_ARGS
+        
+        # Read Neptune outputs for main deployment
+        if [ -f "/tmp/graph-db-outputs/neptune-endpoint.txt" ] && [ -f "/tmp/graph-db-outputs/neptune-sg-id.txt" ]; then
+            NEPTUNE_HOST=$(cat /tmp/graph-db-outputs/neptune-endpoint.txt)
+            NEPTUNE_SG=$(cat /tmp/graph-db-outputs/neptune-sg-id.txt)
+            [ -z "$VPC_ID" ] && [ -f "/tmp/graph-db-outputs/vpc-id.txt" ] && VPC_ID=$(cat /tmp/graph-db-outputs/vpc-id.txt)
+            echo "Using deployed Neptune: $NEPTUNE_HOST (SG: $NEPTUNE_SG)"
+        fi
     fi
+fi
+
+# Check for existing Neptune stack
+if [ -z "$NEPTUNE_HOST" ] && [ -z "$NEPTUNE_SG" ] && [ "$DRY_RUN" != true ]; then
+    echo "Checking for existing Neptune stack..."
+    EXISTING_NEPTUNE_HOST=$(aws cloudformation describe-stacks --stack-name DataExplorerGraphDbStack --query "Stacks[0].Outputs[?ExportName=='GraphDbNeptuneEndpoint'].OutputValue" --output text 2>/dev/null || echo "")
+    EXISTING_NEPTUNE_SG=$(aws cloudformation describe-stacks --stack-name DataExplorerGraphDbStack --query "Stacks[0].Outputs[?ExportName=='GraphDbNeptuneSecurityGroupId'].OutputValue" --output text 2>/dev/null || echo "")
+    EXISTING_VPC_ID=$(aws cloudformation describe-stacks --stack-name DataExplorerGraphDbStack --query "Stacks[0].Outputs[?ExportName=='GraphDbVpcId'].OutputValue" --output text 2>/dev/null || echo "")
     
-    echo "Using deployed Neptune: $NEPTUNE_HOST (SG: $NEPTUNE_SG)"
-  fi
-fi
-
-# Check for existing Neptune stack 
-if [ -z "$NEPTUNE_HOST" ] && [ -z "$NEPTUNE_SG" ]; then
-  echo "Checking for existing Neptune stack..."
-  EXISTING_NEPTUNE_HOST=$(aws cloudformation describe-stacks --stack-name DataExplorerGraphDbStack --query "Stacks[0].Outputs[?ExportName=='GraphDbNeptuneEndpoint'].OutputValue" --output text 2>/dev/null || echo "")
-  EXISTING_NEPTUNE_SG=$(aws cloudformation describe-stacks --stack-name DataExplorerGraphDbStack --query "Stacks[0].Outputs[?ExportName=='GraphDbNeptuneSecurityGroupId'].OutputValue" --output text 2>/dev/null || echo "")
-  EXISTING_VPC_ID=$(aws cloudformation describe-stacks --stack-name DataExplorerGraphDbStack --query "Stacks[0].Outputs[?ExportName=='GraphDbVpcId'].OutputValue" --output text 2>/dev/null || echo "")
-  
-  if [[ -n "$EXISTING_NEPTUNE_HOST" && -n "$EXISTING_NEPTUNE_SG" ]]; then
-    NEPTUNE_HOST="$EXISTING_NEPTUNE_HOST"
-    NEPTUNE_SG="$EXISTING_NEPTUNE_SG"
-    if [ -z "$VPC_ID" ] && [ -n "$EXISTING_VPC_ID" ]; then
-      VPC_ID="$EXISTING_VPC_ID"
+    if [[ -n "$EXISTING_NEPTUNE_HOST" && -n "$EXISTING_NEPTUNE_SG" ]]; then
+        NEPTUNE_HOST="$EXISTING_NEPTUNE_HOST"
+        NEPTUNE_SG="$EXISTING_NEPTUNE_SG"
+        [ -z "$VPC_ID" ] && [ -n "$EXISTING_VPC_ID" ] && VPC_ID="$EXISTING_VPC_ID"
+        echo -e "${GREEN}Found existing Neptune stack${NC}"
     fi
-    echo "Found existing Neptune stack:"
-    echo "  Neptune endpoint: $NEPTUNE_HOST"
-    echo "  Neptune security group: $NEPTUNE_SG"
-    echo "  VPC ID: $VPC_ID"
-  fi
 fi
 
-# Create Knowledge Base first
-echo "Creating Bedrock Knowledge Base..."
-
-# Run knowledge base creation script
-./scripts/kb-create.sh
-
-# Get the created knowledge base details
-HELP_KB_ID=$(cat /tmp/kb-outputs/help-kb-id.txt 2>/dev/null || echo "")
-HELP_KB_ARN=$(cat /tmp/kb-outputs/help-kb-arn.txt 2>/dev/null || echo "")
-PRODUCTS_KB_ID=$(cat /tmp/kb-outputs/products-kb-id.txt 2>/dev/null || echo "")
-PRODUCTS_KB_ARN=$(cat /tmp/kb-outputs/products-kb-arn.txt 2>/dev/null || echo "")
-TARIFFS_KB_ID=$(cat /tmp/kb-outputs/tariffs-kb-id.txt 2>/dev/null || echo "")
-TARIFFS_KB_ARN=$(cat /tmp/kb-outputs/tariffs-kb-arn.txt 2>/dev/null || echo "")
-
-if [[ -n "$HELP_KB_ID" ]]; then
-  echo "Help Knowledge Base created with ID: $HELP_KB_ID"
+# Create Knowledge Base
+if [ "$DRY_RUN" != true ]; then
+    echo -e "${BLUE}Creating Bedrock Knowledge Bases...${NC}"
+    ./scripts/kb-create.sh
+    
+    HELP_KB_ID=$(cat /tmp/kb-outputs/help-kb-id.txt 2>/dev/null || echo "")
+    PRODUCTS_KB_ID=$(cat /tmp/kb-outputs/products-kb-id.txt 2>/dev/null || echo "")
+    TARIFFS_KB_ID=$(cat /tmp/kb-outputs/tariffs-kb-id.txt 2>/dev/null || echo "")
+    
+    [ -n "$HELP_KB_ID" ] && echo -e "${GREEN}✓ Help Knowledge Base: $HELP_KB_ID${NC}"
+    [ -n "$PRODUCTS_KB_ID" ] && echo -e "${GREEN}✓ Products Knowledge Base: $PRODUCTS_KB_ID${NC}"
+    [ -n "$TARIFFS_KB_ID" ] && echo -e "${GREEN}✓ Tariffs Knowledge Base: $TARIFFS_KB_ID${NC}"
 else
-  echo "Warning: Could not retrieve Help Knowledge Base ID"
+    echo -e "${CYAN}[DRY RUN] Would create Bedrock Knowledge Bases${NC}"
 fi
 
-if [[ -n "$PRODUCTS_KB_ID" ]]; then
-  echo "Products Knowledge Base created with ID: $PRODUCTS_KB_ID"
-else
-  echo "Warning: Could not retrieve Products Knowledge Base ID"
-fi
-
-if [[ -n "$TARIFFS_KB_ID" ]]; then
-  echo "Tariffs Knowledge Base created with ID: $TARIFFS_KB_ID"
-else
-  echo "Warning: Could not retrieve Tariffs Knowledge Base ID"
-fi
+# Build CDK command
+echo ""
+echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo -e "${BLUE}Deploying CDK Stack${NC}"
+echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
 
 CDK_COMMAND="CDK_DOCKER=podman npx cdk deploy --app \"npx tsx bin/cdk-app.ts\""
 
-# Add VPC context if provided
-if [ -n "$VPC_ID" ]; then
-  echo "** Deploying to VPC"
-  CDK_COMMAND="$CDK_COMMAND --context vpcId=$VPC_ID"
-else
-  echo "Deploying with new VPC"
-fi
+# Add VPC context
+[ -n "$VPC_ID" ] && CDK_COMMAND="$CDK_COMMAND --context vpcId=$VPC_ID"
+[ -n "$PUBLIC_SUBNET_IDS" ] && CDK_COMMAND="$CDK_COMMAND --context publicSubnetIds=$PUBLIC_SUBNET_IDS"
+[ -n "$PRIVATE_SUBNET_IDS" ] && CDK_COMMAND="$CDK_COMMAND --context privateSubnetIds=$PRIVATE_SUBNET_IDS"
+[ -n "$ALB_SECURITY_GROUP_ID" ] && CDK_COMMAND="$CDK_COMMAND --context albSecurityGroupId=$ALB_SECURITY_GROUP_ID"
+[ -n "$ECS_SECURITY_GROUP_ID" ] && CDK_COMMAND="$CDK_COMMAND --context ecsSecurityGroupId=$ECS_SECURITY_GROUP_ID"
 
-# Add Neptune/Graph database context if available
+# Add Neptune context
 if [ -n "$NEPTUNE_HOST" ]; then
-  echo "** Deploying with Graph Database integration"
-  CDK_COMMAND="$CDK_COMMAND \
-    --context withGraphDb=true \
-    --context neptuneHost=$NEPTUNE_HOST \
-    --context neptuneSgId=$NEPTUNE_SG"
+    CDK_COMMAND="$CDK_COMMAND --context withGraphDb=true"
+    CDK_COMMAND="$CDK_COMMAND --context neptuneHost=$NEPTUNE_HOST"
+    CDK_COMMAND="$CDK_COMMAND --context neptuneSgId=$NEPTUNE_SG"
 fi
 
-# Add guardrails context (always enabled now)
-echo "** Deploying with Bedrock Guardrails"
-
-CDK_COMMAND="$CDK_COMMAND \
-  --context guardrailMode=$GUARDRAIL_MODE"
-
+# Add guardrails context
+CDK_COMMAND="$CDK_COMMAND --context guardrailMode=$GUARDRAIL_MODE"
 CDK_COMMAND="$CDK_COMMAND --require-approval never"
 
 # Execute deployment
-eval $CDK_COMMAND
-
-
-# Show configuration summary
-if [ -n "$VPC_ID" ]; then
-  echo ""
-  echo "VPC Configuration:"
-  echo "  Used existing VPC: $VPC_ID"
-fi
-
-if [ -n "$NEPTUNE_HOST" ]; then
-  echo ""
-  echo "Neptune Configuration:"
-  echo "  Neptune endpoint: $NEPTUNE_HOST"
-  echo "  Neptune security group: $NEPTUNE_SG"
-fi
-
-echo ""
-echo "Guardrail Configuration:"
-echo "  Mode: $GUARDRAIL_MODE"
-if [ "$GUARDRAIL_MODE" = "shadow" ]; then
-  echo "  - Content will NOT be blocked"
-  echo "  - Violations will be logged for monitoring"
-  echo "  - Check container logs for [GUARDRAIL] messages"
+if [ "$DRY_RUN" = true ]; then
+    echo -e "${CYAN}[DRY RUN] Would execute:${NC}"
+    echo "$CDK_COMMAND"
+    echo ""
+    echo -e "${CYAN}[DRY RUN] Synthesizing templates to validate...${NC}"
+    CDK_DOCKER=podman npx cdk synth --app "npx tsx bin/cdk-app.ts" --quiet || true
+    echo -e "${GREEN}✓ Dry run completed${NC}"
 else
-  echo "  - Content WILL be blocked if it violates policies"
-  echo "  - Blocked content will be replaced with safe messages"
+    eval $CDK_COMMAND
 fi
 
-# Get deployment URLs
-ALB_URL=$(aws cloudformation describe-stacks --stack-name DataExplorerAgentsStack --query "Stacks[0].Outputs[?ExportName=='ALBEndpoint'].OutputValue" --output text 2>/dev/null || echo "Not available")
-CLOUDFRONT_URL=$(aws cloudformation describe-stacks --stack-name DataExplorerAgentsStack --query "Stacks[0].Outputs[?ExportName=='ApplicationUrl'].OutputValue" --output text 2>/dev/null || echo "Not available")
-
+# Show deployment summary
 echo ""
-echo "Deployment Complete!"
-echo "======================="
-echo "  CloudFront URL (HTTPS): $CLOUDFRONT_URL"
-echo "  Direct ALB URL (HTTP): $ALB_URL"
+echo -e "${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo -e "${GREEN}Deployment Complete!${NC}"
+echo -e "${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+
+if [ "$DRY_RUN" != true ]; then
+    ALB_URL=$(aws cloudformation describe-stacks --stack-name DataExplorerAgentsStack --query "Stacks[0].Outputs[?ExportName=='ALBEndpoint'].OutputValue" --output text 2>/dev/null || echo "Not available")
+    CLOUDFRONT_URL=$(aws cloudformation describe-stacks --stack-name DataExplorerAgentsStack --query "Stacks[0].Outputs[?ExportName=='ApplicationUrl'].OutputValue" --output text 2>/dev/null || echo "Not available")
+    
+    echo ""
+    echo "  CloudFront URL (HTTPS): $CLOUDFRONT_URL"
+fi
+
 echo ""

--- a/docker/app/version.json
+++ b/docker/app/version.json
@@ -1,5 +1,5 @@
 {
   "version": "2.0.1",
-  "build_date": "2026-01-09T07:19:17.267Z",
+  "build_date": "2026-01-09T13:24:08.120Z",
   "git_commit": "local-dev"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "panoptic-agent-app",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Panoptic AI Data Explorer",
   "private": true,
   "bin": {

--- a/scripts/kb-create.ps1
+++ b/scripts/kb-create.ps1
@@ -1,0 +1,440 @@
+<#
+.SYNOPSIS
+    Create Bedrock Knowledge Bases for AI Data Explorer (Windows PowerShell version)
+
+.DESCRIPTION
+    Creates IAM roles, S3 buckets, S3 vector stores, and Bedrock Knowledge Bases
+    for the AI Data Explorer application.
+
+.EXAMPLE
+    .\kb-create.ps1
+#>
+
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = "Stop"
+
+# Disable AWS CLI pager
+$env:AWS_PAGER = ""
+
+# Set APP_NAME if not already set
+if (-not $env:APP_NAME) {
+    $env:APP_NAME = "ai-data-explorer"
+}
+$APP_NAME = $env:APP_NAME
+
+# Set AWS_REGION if not already set
+if (-not $env:AWS_REGION) {
+    $env:AWS_REGION = aws configure get region
+}
+$AWS_REGION = $env:AWS_REGION
+
+# Set EMBEDDING_MODEL
+$EMBEDDING_MODEL = "arn:aws:bedrock:${AWS_REGION}::foundation-model/amazon.titan-embed-text-v2:0"
+$env:EMBEDDING_MODEL = $EMBEDDING_MODEL
+
+# Get account ID
+$ACCOUNT = aws sts get-caller-identity --query Account --output text
+$SOURCE_BUCKET_NAME = "${APP_NAME}-kb-${ACCOUNT}-${AWS_REGION}"
+$SOURCE_BUCKET_ARN = "arn:aws:s3:::${SOURCE_BUCKET_NAME}"
+
+# Create IAM role for Bedrock Knowledge Base
+$ROLE_NAME = "BedrockKBRole-${APP_NAME}"
+Write-Host "Creating IAM role: $ROLE_NAME"
+
+# Trust policy
+$trustPolicy = @"
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "bedrock.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+"@
+
+$trustPolicyFile = [System.IO.Path]::GetTempFileName()
+$trustPolicy | Out-File -FilePath $trustPolicyFile -Encoding utf8
+
+# Create role
+$ROLE_CREATED = $false
+try {
+    aws iam create-role `
+        --role-name $ROLE_NAME `
+        --assume-role-policy-document "file://$trustPolicyFile" `
+        --output json 2>$null | Out-Null
+    Write-Host "Created new IAM role: $ROLE_NAME"
+    $ROLE_CREATED = $true
+} catch {
+    Write-Host "Role $ROLE_NAME already exists"
+}
+
+Remove-Item $trustPolicyFile -Force
+
+# Role policy
+$rolePolicy = @"
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "BedrockInvokeModelStatement",
+      "Effect": "Allow",
+      "Action": ["bedrock:InvokeModel"],
+      "Resource": ["${EMBEDDING_MODEL}"]
+    },
+    {
+      "Sid": "S3ListBucketStatement",
+      "Effect": "Allow",
+      "Action": ["s3:ListBucket"],
+      "Resource": ["${SOURCE_BUCKET_ARN}"],
+      "Condition": {
+        "StringEquals": {
+          "aws:ResourceAccount": "${ACCOUNT}"
+        }
+      }
+    },
+    {
+      "Sid": "S3GetObjectStatement",
+      "Effect": "Allow",
+      "Action": ["s3:GetObject"],
+      "Resource": ["${SOURCE_BUCKET_ARN}/*"],
+      "Condition": {
+        "StringEquals": {
+          "aws:ResourceAccount": "${ACCOUNT}"
+        }
+      }
+    },
+    {
+      "Sid": "S3VectorsStatement",
+      "Effect": "Allow",
+      "Action": [
+        "s3vectors:QueryVectors",
+        "s3vectors:PutVectors",
+        "s3vectors:DeleteVectors",
+        "s3vectors:GetVectors",
+        "s3vectors:ListVectors",
+        "s3vectors:GetIndex",
+        "s3vectors:ListIndexes",
+        "s3vectors:GetVectorBucket",
+        "s3vectors:ListVectorBuckets"
+      ],
+      "Resource": [
+        "arn:aws:s3vectors:${AWS_REGION}:${ACCOUNT}:bucket/${APP_NAME}-help-vectors-${AWS_REGION}",
+        "arn:aws:s3vectors:${AWS_REGION}:${ACCOUNT}:bucket/${APP_NAME}-help-vectors-${AWS_REGION}/*",
+        "arn:aws:s3vectors:${AWS_REGION}:${ACCOUNT}:bucket/${APP_NAME}-help-vectors-${AWS_REGION}/index/${APP_NAME}-help-index-${AWS_REGION}",
+        "arn:aws:s3vectors:${AWS_REGION}:${ACCOUNT}:bucket/${APP_NAME}-products-vectors-${AWS_REGION}",
+        "arn:aws:s3vectors:${AWS_REGION}:${ACCOUNT}:bucket/${APP_NAME}-products-vectors-${AWS_REGION}/*",
+        "arn:aws:s3vectors:${AWS_REGION}:${ACCOUNT}:bucket/${APP_NAME}-products-vectors-${AWS_REGION}/index/${APP_NAME}-products-index-${AWS_REGION}",
+        "arn:aws:s3vectors:${AWS_REGION}:${ACCOUNT}:bucket/${APP_NAME}-tariffs-vectors-${AWS_REGION}",
+        "arn:aws:s3vectors:${AWS_REGION}:${ACCOUNT}:bucket/${APP_NAME}-tariffs-vectors-${AWS_REGION}/*",
+        "arn:aws:s3vectors:${AWS_REGION}:${ACCOUNT}:bucket/${APP_NAME}-tariffs-vectors-${AWS_REGION}/index/${APP_NAME}-tariffs-index-${AWS_REGION}"
+      ]
+    }
+  ]
+}
+"@
+
+$rolePolicyFile = [System.IO.Path]::GetTempFileName()
+$rolePolicy | Out-File -FilePath $rolePolicyFile -Encoding utf8
+
+# Attach policy to role
+aws iam put-role-policy `
+    --role-name $ROLE_NAME `
+    --policy-name "${ROLE_NAME}-Policy" `
+    --policy-document "file://$rolePolicyFile"
+
+Remove-Item $rolePolicyFile -Force
+
+$KB_ROLE_ARN = "arn:aws:iam::${ACCOUNT}:role/${ROLE_NAME}"
+Write-Host "Created IAM role: $KB_ROLE_ARN"
+
+# Wait for role propagation only if role was just created
+if ($ROLE_CREATED) {
+    Write-Host "Waiting for IAM role to propagate..."
+    Start-Sleep -Seconds 10
+}
+
+# Create S3 bucket for knowledge base documents
+Write-Host "Creating S3 bucket: $SOURCE_BUCKET_NAME"
+try {
+    if ($AWS_REGION -eq "us-east-1") {
+        aws s3api create-bucket `
+            --bucket $SOURCE_BUCKET_NAME `
+            --region $AWS_REGION 2>$null | Out-Null
+    } else {
+        aws s3api create-bucket `
+            --bucket $SOURCE_BUCKET_NAME `
+            --region $AWS_REGION `
+            --create-bucket-configuration "LocationConstraint=$AWS_REGION" 2>$null | Out-Null
+    }
+} catch {
+    Write-Host "S3 bucket $SOURCE_BUCKET_NAME already exists"
+}
+
+Write-Host "S3 source bucket configured: $SOURCE_BUCKET_ARN"
+
+# Function to create vector bucket and index
+function New-VectorBucketAndIndex {
+    param(
+        [string]$Name,
+        [string]$AppName,
+        [string]$Region
+    )
+    
+    $vectorBucketName = "${AppName}-${Name}-vectors-${Region}"
+    $indexName = "${AppName}-${Name}-index-${Region}"
+    
+    # Create S3 vector bucket
+    Write-Host "Creating S3 vector bucket: $vectorBucketName"
+    try {
+        aws s3vectors create-vector-bucket --vector-bucket-name $vectorBucketName 2>$null | Out-Null
+    } catch {
+        Write-Host "Vector bucket $vectorBucketName already exists"
+    }
+    
+    # Get the vector bucket ARN
+    $vectorBucketArn = aws s3vectors get-vector-bucket `
+        --vector-bucket-name $vectorBucketName `
+        --query 'vectorBucket.vectorBucketArn' `
+        --output text
+    
+    Write-Host "Created $Name vector bucket: $vectorBucketArn"
+    
+    # Create S3 vector index
+    Write-Host "Creating S3 vector index: $indexName"
+    try {
+        aws s3vectors create-index `
+            --vector-bucket-name $vectorBucketName `
+            --index-name $indexName `
+            --data-type "float32" `
+            --dimension 1024 `
+            --distance-metric "cosine" `
+            --metadata-configuration '{"nonFilterableMetadataKeys":["AMAZON_BEDROCK_TEXT","AMAZON_BEDROCK_METADATA"]}' 2>$null | Out-Null
+    } catch {
+        Write-Host "Vector index $indexName already exists"
+    }
+    
+    # Get the vector index ARN
+    $indexArn = aws s3vectors get-index `
+        --vector-bucket-name $vectorBucketName `
+        --index-name $indexName `
+        --query 'index.indexArn' `
+        --output text
+    
+    Write-Host "Created $Name vector index: $indexArn"
+    
+    return @{
+        VectorBucketArn = $vectorBucketArn
+        IndexArn = $indexArn
+    }
+}
+
+# Create vector buckets and indexes for each KB
+$helpVectors = New-VectorBucketAndIndex -Name "help" -AppName $APP_NAME -Region $AWS_REGION
+$productsVectors = New-VectorBucketAndIndex -Name "products" -AppName $APP_NAME -Region $AWS_REGION
+$tariffsVectors = New-VectorBucketAndIndex -Name "tariffs" -AppName $APP_NAME -Region $AWS_REGION
+
+# Function to create or get knowledge base
+function New-OrGetKnowledgeBase {
+    param(
+        [string]$Name,
+        [string]$AppName,
+        [string]$RoleArn,
+        [string]$EmbeddingModel,
+        [string]$IndexArn,
+        [string]$VectorBucketArn
+    )
+    
+    $kbName = "${AppName}-${Name}"
+    
+    Write-Host "Creating Bedrock $Name knowledge base..."
+    
+    # Check if KB already exists
+    $existingKb = aws bedrock-agent list-knowledge-bases `
+        --query "knowledgeBaseSummaries[?name=='$kbName'].knowledgeBaseId" `
+        --output text 2>$null
+    
+    if ($existingKb -and $existingKb -ne "None" -and $existingKb.Trim()) {
+        Write-Host "Knowledge base '$kbName' already exists with ID: $existingKb"
+        $kbArn = aws bedrock-agent get-knowledge-base `
+            --knowledge-base-id $existingKb `
+            --query 'knowledgeBase.knowledgeBaseArn' `
+            --output text
+        
+        return @{
+            Id = $existingKb.Trim()
+            Arn = $kbArn
+        }
+    }
+    
+    # Create new knowledge base with retry logic
+    $kbConfig = @{
+        type = "VECTOR"
+        vectorKnowledgeBaseConfiguration = @{
+            embeddingModelArn = $EmbeddingModel
+        }
+    } | ConvertTo-Json -Compress
+    
+    $storageConfig = @{
+        type = "S3_VECTORS"
+        s3VectorsConfiguration = @{
+            indexArn = $IndexArn
+            vectorBucketArn = $VectorBucketArn
+        }
+    } | ConvertTo-Json -Compress
+    
+    for ($i = 1; $i -le 3; $i++) {
+        Write-Host "$Name KB Attempt $i of 3..."
+        
+        try {
+            $kbJson = aws bedrock-agent create-knowledge-base `
+                --name $kbName `
+                --role-arn $RoleArn `
+                --knowledge-base-configuration $kbConfig `
+                --storage-configuration $storageConfig `
+                --output json 2>&1
+            
+            $kb = $kbJson | ConvertFrom-Json
+            Write-Host "Knowledge base created successfully"
+            
+            return @{
+                Id = $kb.knowledgeBase.knowledgeBaseId
+                Arn = $kb.knowledgeBase.knowledgeBaseArn
+            }
+        } catch {
+            if ($i -eq 3) {
+                Write-Host "Failed to create $Name knowledge base after 3 attempts"
+                Write-Host $_.Exception.Message
+                throw
+            }
+            Write-Host "$Name KB Attempt $i failed, retrying in 15 seconds..."
+            Start-Sleep -Seconds 15
+        }
+    }
+}
+
+# Create knowledge bases
+$helpKb = New-OrGetKnowledgeBase -Name "help" -AppName $APP_NAME -RoleArn $KB_ROLE_ARN `
+    -EmbeddingModel $EMBEDDING_MODEL -IndexArn $helpVectors.IndexArn -VectorBucketArn $helpVectors.VectorBucketArn
+
+$productsKb = New-OrGetKnowledgeBase -Name "products" -AppName $APP_NAME -RoleArn $KB_ROLE_ARN `
+    -EmbeddingModel $EMBEDDING_MODEL -IndexArn $productsVectors.IndexArn -VectorBucketArn $productsVectors.VectorBucketArn
+
+$tariffsKb = New-OrGetKnowledgeBase -Name "tariffs" -AppName $APP_NAME -RoleArn $KB_ROLE_ARN `
+    -EmbeddingModel $EMBEDDING_MODEL -IndexArn $tariffsVectors.IndexArn -VectorBucketArn $tariffsVectors.VectorBucketArn
+
+# Create output directory (use Windows temp path)
+$outputDir = Join-Path $env:TEMP "kb-outputs"
+if (-not (Test-Path $outputDir)) {
+    New-Item -ItemType Directory -Path $outputDir -Force | Out-Null
+}
+
+# Also create in WSL-compatible location if possible
+try {
+    wsl mkdir -p /tmp/kb-outputs 2>$null
+    wsl bash -c "echo -n '$($helpKb.Id)' > /tmp/kb-outputs/help-kb-id.txt" 2>$null
+    wsl bash -c "echo -n '$($helpKb.Arn)' > /tmp/kb-outputs/help-kb-arn.txt" 2>$null
+    wsl bash -c "echo -n '$($productsKb.Id)' > /tmp/kb-outputs/products-kb-id.txt" 2>$null
+    wsl bash -c "echo -n '$($productsKb.Arn)' > /tmp/kb-outputs/products-kb-arn.txt" 2>$null
+    wsl bash -c "echo -n '$($tariffsKb.Id)' > /tmp/kb-outputs/tariffs-kb-id.txt" 2>$null
+    wsl bash -c "echo -n '$($tariffsKb.Arn)' > /tmp/kb-outputs/tariffs-kb-arn.txt" 2>$null
+} catch {
+    # WSL not available, use Windows paths only
+}
+
+# Save to Windows temp
+$helpKb.Id | Out-File -FilePath (Join-Path $outputDir "help-kb-id.txt") -NoNewline -Encoding utf8
+$helpKb.Arn | Out-File -FilePath (Join-Path $outputDir "help-kb-arn.txt") -NoNewline -Encoding utf8
+$productsKb.Id | Out-File -FilePath (Join-Path $outputDir "products-kb-id.txt") -NoNewline -Encoding utf8
+$productsKb.Arn | Out-File -FilePath (Join-Path $outputDir "products-kb-arn.txt") -NoNewline -Encoding utf8
+$tariffsKb.Id | Out-File -FilePath (Join-Path $outputDir "tariffs-kb-id.txt") -NoNewline -Encoding utf8
+$tariffsKb.Arn | Out-File -FilePath (Join-Path $outputDir "tariffs-kb-arn.txt") -NoNewline -Encoding utf8
+
+Write-Host ""
+Write-Host "Help Knowledge Base created:"
+Write-Host "  ID: $($helpKb.Id)"
+Write-Host "  ARN: $($helpKb.Arn)"
+Write-Host ""
+Write-Host "Products Knowledge Base created:"
+Write-Host "  ID: $($productsKb.Id)"
+Write-Host "  ARN: $($productsKb.Arn)"
+Write-Host ""
+Write-Host "Tariffs Knowledge Base created:"
+Write-Host "  ID: $($tariffsKb.Id)"
+Write-Host "  ARN: $($tariffsKb.Arn)"
+
+# Function to create or get data source
+function New-OrGetDataSource {
+    param(
+        [string]$Name,
+        [string]$AppName,
+        [string]$KbId,
+        [string]$BucketArn,
+        [string]$Prefix
+    )
+    
+    $dsName = "${AppName}-${Name}-datasource"
+    
+    Write-Host "Creating $Name data source for S3 bucket..."
+    
+    # Check if data source already exists
+    $existingDs = aws bedrock-agent list-data-sources `
+        --knowledge-base-id $KbId `
+        --query "dataSourceSummaries[?name=='$dsName'].dataSourceId" `
+        --output text 2>$null
+    
+    if ($existingDs -and $existingDs -ne "None" -and $existingDs.Trim()) {
+        Write-Host "Data source '$dsName' already exists with ID: $existingDs"
+        return $existingDs.Trim()
+    }
+    
+    # Create new data source
+    $dsConfig = @{
+        type = "S3"
+        s3Configuration = @{
+            bucketArn = $BucketArn
+            inclusionPrefixes = @($Prefix)
+        }
+    } | ConvertTo-Json -Compress
+    
+    $dsJson = aws bedrock-agent create-data-source `
+        --knowledge-base-id $KbId `
+        --name $dsName `
+        --data-source-configuration $dsConfig `
+        --data-deletion-policy "RETAIN" `
+        --output json
+    
+    $ds = $dsJson | ConvertFrom-Json
+    $dsId = $ds.dataSource.dataSourceId
+    Write-Host "$Name data source created: $dsId"
+    
+    return $dsId
+}
+
+# Create data sources
+$helpDsId = New-OrGetDataSource -Name "help" -AppName $APP_NAME -KbId $helpKb.Id -BucketArn $SOURCE_BUCKET_ARN -Prefix "docs/"
+$productsDsId = New-OrGetDataSource -Name "products" -AppName $APP_NAME -KbId $productsKb.Id -BucketArn $SOURCE_BUCKET_ARN -Prefix "products/"
+$tariffsDsId = New-OrGetDataSource -Name "tariffs" -AppName $APP_NAME -KbId $tariffsKb.Id -BucketArn $SOURCE_BUCKET_ARN -Prefix "tariffs/"
+
+# Save data source IDs
+$helpDsId | Out-File -FilePath (Join-Path $outputDir "help-data-source-id.txt") -NoNewline -Encoding utf8
+$productsDsId | Out-File -FilePath (Join-Path $outputDir "products-data-source-id.txt") -NoNewline -Encoding utf8
+$tariffsDsId | Out-File -FilePath (Join-Path $outputDir "tariffs-data-source-id.txt") -NoNewline -Encoding utf8
+
+# Also save to WSL paths if available
+try {
+    wsl bash -c "echo -n '$helpDsId' > /tmp/kb-outputs/help-data-source-id.txt" 2>$null
+    wsl bash -c "echo -n '$productsDsId' > /tmp/kb-outputs/products-data-source-id.txt" 2>$null
+    wsl bash -c "echo -n '$tariffsDsId' > /tmp/kb-outputs/tariffs-data-source-id.txt" 2>$null
+} catch {
+    # WSL not available
+}
+
+Write-Host ""
+Write-Host "KB outputs saved to: $outputDir"

--- a/ui/version.json
+++ b/ui/version.json
@@ -1,5 +1,5 @@
 {
   "version": "2.0.1",
-  "build_date": "2026-01-09T07:19:17.267Z",
+  "build_date": "2026-01-09T13:24:08.120Z",
   "git_commit": "local-dev"
 }


### PR DESCRIPTION
**dev-tools/deploy.sh - Complete rewrite with new CLI options:**

-   --profile, --region, --account for explicit AWS configuration
-   --public-subnet-ids, --private-subnet-ids for explicit subnet selection
-   --alb-security-group-id, --ecs-security-group-id for bring-your-own SGs
-   --dry-run for validation without deployment
-   --skip-bootstrap-check to bypass CDK bootstrap verification
-   Better error messages and configuration summary display

**lib/agent-fargate-stack.ts - CDK stack updates:**

- VPC import now supports explicit subnet IDs (bypasses tag-based lookup)
- Security groups can be imported instead of created
- ALB and ECS services use the appropriate subnet selection
- Backwards compatible — no params = same behavior as before
- scripts/cloudshell-deploy.sh - Updated with same CLI options

**dev-tools/deploy-graph-db.sh** - Added --profile, --region, --dry-run

**README.md** - Added enterprise deployment documentation:

**Full CLI options table**

- Required VPC endpoints list
- Security group requirements
- .kiro/steering/tech.md - Updated deployment examples

**Backwards Compatibility:**

- Existing deployments can update in place
- Running ./dev-tools/deploy.sh with no args still works (auto-detects region/account)
- New VPC is still created if --vpc-id not provided
- 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
